### PR TITLE
Update AGENTS workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,10 @@ Focus on Kotlin modules and core workflows (build, lint, test).
 - `make test`
 - `make detekt`
 - `make check` (detekt + tests)
+- `make docs-install`
+- `make docs-build`
+- `make docs-serve`
+- `make docs-clean`
 
 ### Run a Single Test (JUnit 5)
 
@@ -59,6 +63,14 @@ Focus on Kotlin modules and core workflows (build, lint, test).
 
 - `./gradlew :kontracts:test --tests 'io.amichne.kontracts.SchemaDslTest'`
 - `./gradlew :konditional-runtime:test --tests 'io.amichne.konditional.runtime.SomeTest'`
+
+### Publishing Scripts
+
+- `./scripts/validate-publish.sh`
+- `./scripts/publish.sh local`
+- `./scripts/publish.sh snapshot`
+- `./scripts/publish.sh release`
+- `./scripts/publish.sh github`
 
 ## Code Style Guidelines
 


### PR DESCRIPTION
This PR updates `AGENTS.md` to include workflows and commands that exist in this repo but were previously undocumented.

What changed
- Added the Docusaurus-related Make targets: `make docs-install`, `make docs-build`, `make docs-serve`, `make docs-clean`.
- Added the publish-related scripts under `./scripts/` (validate + publish targets).

Why
- These commands are part of the normal repo workflow (Makefile + scripts directory) and are useful for contributors and agents.
- Keeping them in `AGENTS.md` reduces "tribal knowledge" and avoids re-discovery.

Impact
- Documentation-only change; no runtime/library behavior changes.

Validation
- `make check` (detekt + tests)
