### PR TITLE
Integrate release plugin and normalize version handling

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -23,62 +23,65 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.ref_name }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Compute next version
+      - name: Run release automation
+        run: |
+          ./gradlew release \
+            --no-configuration-cache \
+            --no-daemon \
+            --stacktrace \
+            -Prelease.useAutomaticVersion=true \
+            -PreleaseType="${{ github.event.inputs.release-type }}"
+
+      - name: Capture release versions
         id: version
         run: |
-          CURRENT_VERSION=$(grep "^VERSION=" gradle.properties | cut -d'=' -f2)
-          BASE_VERSION=${CURRENT_VERSION%-SNAPSHOT}
+          STORE_FILE="build/release/tmpVersion.properties"
+          if [ ! -f "$STORE_FILE" ]; then
+            echo "Missing release version store: $STORE_FILE"
+            exit 1
+          fi
 
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+          RELEASE_VERSION="$(grep '^releaseVersion=' "$STORE_FILE" | cut -d'=' -f2)"
+          NEXT_DEV_VERSION="$(grep '^postReleaseVersion=' "$STORE_FILE" | cut -d'=' -f2)"
 
-          case "${{ github.event.inputs.release-type }}" in
-            major)
-              MAJOR=$((MAJOR + 1))
-              MINOR=0
-              PATCH=0
-              ;;
-            minor)
-              MINOR=$((MINOR + 1))
-              PATCH=0
-              ;;
-            patch)
-              PATCH=$((PATCH + 1))
-              ;;
-          esac
+          if [ -z "$RELEASE_VERSION" ] || [ -z "$NEXT_DEV_VERSION" ]; then
+            echo "Unable to parse releaseVersion/postReleaseVersion from $STORE_FILE"
+            exit 1
+          fi
 
-          NEXT_VERSION="$MAJOR.$MINOR.$PATCH"
+          RELEASE_TAG="v$RELEASE_VERSION"
+          if ! git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release tag '$RELEASE_TAG' was not created locally."
+            exit 1
+          fi
 
-          echo "current=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-          echo "next=$NEXT_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Update version
-        run: |
-          NEXT_VERSION="${{ steps.version.outputs.next }}"
-          sed -i.bak "s/^VERSION=.*/VERSION=$NEXT_VERSION/" gradle.properties
-          rm -f gradle.properties.bak
-          git add gradle.properties
-          git commit -m "chore(release): v$NEXT_VERSION"
-
-      - name: Tag release
-        run: |
-          NEXT_VERSION="${{ steps.version.outputs.next }}"
-          git tag "v$NEXT_VERSION"
-          git push origin "v$NEXT_VERSION"
+          echo "release=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "next=$NEXT_DEV_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Summary
         run: |
           cat << EOF >> $GITHUB_STEP_SUMMARY
-          ## Release Prepared
+          ## Release Cut
 
           **Release type:** \`${{ github.event.inputs.release-type }}\`
-          **Previous version:** \`${{ steps.version.outputs.current }}\`
-          **New version:** \`v${{ steps.version.outputs.next }}\`
+          **Release tag:** \`${{ steps.version.outputs.tag }}\`
+          **Release version:** \`${{ steps.version.outputs.release }}\`
+          **Next development version:** \`${{ steps.version.outputs.next }}\`
 
-          This workflow pushes a commit and tag that triggers the \`Release\` workflow.
+          The release plugin pushed release and post-release commits plus tag, which triggers the \`Release\` workflow.
           EOF

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -37,7 +37,7 @@ jobs:
           VERSION="${{ github.event.inputs.snapshot-version }}"
 
           if [ -z "$VERSION" ]; then
-            BASE_VERSION="$(grep '^VERSION=' gradle.properties | cut -d'=' -f2)"
+            BASE_VERSION="$(grep -E '^(version|VERSION)=' gradle.properties | head -n1 | cut -d'=' -f2)"
             if [[ "$BASE_VERSION" =~ -SNAPSHOT$ ]]; then
               VERSION="$BASE_VERSION"
             else
@@ -55,7 +55,7 @@ jobs:
       - name: Run tests
         env:
           VERSION: ${{ steps.snapshot-version.outputs.value }}
-        run: ./gradlew -PVERSION="$VERSION" test --no-daemon
+        run: ./gradlew -Pversion="$VERSION" test --no-daemon
 
   publish-github-packages:
     runs-on: ubuntu-latest
@@ -111,7 +111,7 @@ jobs:
             SIGNING_ARGS+=(-Psigning.gnupg.passphrase="$SIGNING_GPG_PASSPHRASE")
           fi
 
-          ./gradlew -PVERSION="$VERSION" publishMavenPublicationToGitHubPackagesRepository "${SIGNING_ARGS[@]}" \
+          ./gradlew -Pversion="$VERSION" publishMavenPublicationToGitHubPackagesRepository "${SIGNING_ARGS[@]}" \
             --no-configuration-cache \
             --no-daemon \
             --stacktrace
@@ -188,7 +188,7 @@ jobs:
             SIGNING_ARGS+=(-Psigning.gnupg.passphrase="$SIGNING_GPG_PASSPHRASE")
           fi
 
-          ./gradlew -PVERSION="$VERSION" publishToMavenCentral "${SIGNING_ARGS[@]}" \
+          ./gradlew -Pversion="$VERSION" publishToMavenCentral "${SIGNING_ARGS[@]}" \
             --no-configuration-cache \
             --no-daemon \
             --stacktrace

--- a/build-logic/src/main/kotlin/io/amichne/konditional/gradle/PublishingConventions.kt
+++ b/build-logic/src/main/kotlin/io/amichne/konditional/gradle/PublishingConventions.kt
@@ -41,6 +41,13 @@ private fun normalizeGithubRepository(value: String): String? {
     return candidate?.removeSuffix(".git")?.trim()?.takeIf { it.isNotBlank() }
 }
 
+private fun Project.resolveProjectVersion(props: Map<String, *>): String =
+    providers.gradleProperty("version").orNull
+        ?: providers.gradleProperty("VERSION").orNull
+        ?: (props["version"] as? String)
+        ?: (props["VERSION"] as? String)
+        ?: error("Missing project version property. Define 'version' in gradle.properties.")
+
 /**
  * Configures Maven publishing with complete POM metadata for a Konditional module.
  *
@@ -60,6 +67,7 @@ fun Project.configureKonditionalPublishing(
 ) {
     val publishTarget = resolvePublishTarget()
     val props = rootProject.properties
+    val projectVersion = resolveProjectVersion(props)
     val githubRepository = sequenceOf(
         props["GITHUB_REPOSITORY"] as? String,
         props["gpr.repo"] as? String,
@@ -90,7 +98,7 @@ fun Project.configureKonditionalPublishing(
             publication.apply {
                 this.groupId = props["GROUP"] as String
                 this.artifactId = artifactId
-                this.version = props["VERSION"] as String
+                this.version = projectVersion
 
                 pom {
                     name.set(moduleName)

--- a/build-logic/src/main/kotlin/konditional.kotlin-library.gradle.kts
+++ b/build-logic/src/main/kotlin/konditional.kotlin-library.gradle.kts
@@ -5,9 +5,10 @@ plugins {
     `java-library`
 }
 
-val props = rootProject.properties
-group = props["GROUP"] as String
-version = props["VERSION"] as String
+group = providers.gradleProperty("GROUP").get()
+version = providers.gradleProperty("version")
+    .orElse(providers.gradleProperty("VERSION"))
+    .get()
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,15 @@
-val props = project.properties
-group = props["GROUP"] as String
-version = props["VERSION"] as String
+plugins {
+    id("io.github.simonhauck.release") version "1.5.1"
+}
+
+group = providers.gradleProperty("GROUP").get()
+version = providers.gradleProperty("version")
+    .orElse(providers.gradleProperty("VERSION"))
+    .get()
+
+release {
+    versionPropertyFile.set(layout.projectDirectory.file("gradle.properties"))
+    releaseCommitMessage.set("chore(release): v{version}")
+    postReleaseCommitMessage.set("chore(release): prepare v{version}")
+    ignorePreReleaseDependencies.add("io.opentelemetry:opentelemetry-semconv")
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project Information
 GROUP=io.github.amichne
-VERSION=0.1.3
+version=0.1.3
 ARTIFACT_ID=konditional
 JRELEASER_VERSION=1.12.0
 # Library Information

--- a/scripts/validate-publish.sh
+++ b/scripts/validate-publish.sh
@@ -58,14 +58,14 @@ check_version_for_target() {
   case "$TARGET" in
     snapshot)
       if [[ "$version" != *"-SNAPSHOT" ]]; then
-        fail "snapshot publish requires VERSION to end with -SNAPSHOT (found $version)"
+        fail "snapshot publish requires version to end with -SNAPSHOT (found $version)"
       else
         pass "snapshot version detected: $version"
       fi
       ;;
     release)
       if [[ "$version" == *"-SNAPSHOT" ]]; then
-        fail "release publish requires non-SNAPSHOT VERSION (found $version)"
+        fail "release publish requires non-SNAPSHOT version (found $version)"
       else
         pass "release version detected: $version"
       fi
@@ -128,10 +128,13 @@ echo -e "${BOLD}[1/7] Checking gradle.properties and target version constraints.
 if [[ ! -f "gradle.properties" ]]; then
   fail "gradle.properties not found"
 else
-  VERSION="$(value_from_props "VERSION" "gradle.properties")"
+  VERSION="$(value_from_props "version" "gradle.properties")"
+  if [[ -z "$VERSION" ]]; then
+    VERSION="$(value_from_props "VERSION" "gradle.properties")"
+  fi
   GROUP="$(value_from_props "GROUP" "gradle.properties")"
 
-  [[ -n "$VERSION" ]] && pass "VERSION=$VERSION" || fail "Missing VERSION in gradle.properties"
+  [[ -n "$VERSION" ]] && pass "version=$VERSION" || fail "Missing version in gradle.properties"
   [[ -n "$GROUP" ]] && pass "GROUP=$GROUP" || fail "Missing GROUP in gradle.properties"
 
   if [[ -n "$VERSION" ]]; then


### PR DESCRIPTION
Summary
- wire `io.github.simonhauck.release` into the root build and document its behaviors
- adjust publishing convention and scripts to read the canonical `version` property while keeping legacy `VERSION` touchpoints in sync
- update release and snapshot workflows to rely on the plugin outputs, new Java 21 step, and consistent property consumption

Testing
- Not run (not requested)