### PR TITLE
Fix primitive Konstrained reflection and regenerate recipes docs

### DIFF
--- a/docusaurus/docs/advanced/recipes.md
+++ b/docusaurus/docs/advanced/recipes.md
@@ -324,5 +324,5 @@ fun attachHooks() {
 - [Rules & Targeting: Rule Composition](/rules-and-targeting/rule-composition)
 - [Rules & Targeting: Rollout Strategies](/rules-and-targeting/rollout-strategies)
 - [Fundamentals: Configuration Lifecycle](/learn/configuration-lifecycle)
-- [Shadow Evaluation](/observability/shadow-evaluation)
-- [Observability Reference](/observability/reference)
+- [Advanced: Shadow Evaluation](/advanced/shadow-evaluation)
+- [API Reference: Observability](/api-reference/observability)

--- a/konditional-serialization/src/main/kotlin/io/amichne/konditional/serialization/SchemaValueCodec.kt
+++ b/konditional-serialization/src/main/kotlin/io/amichne/konditional/serialization/SchemaValueCodec.kt
@@ -352,10 +352,22 @@ object SchemaValueCodec {
  */
 private inline fun <reified T : Any> Konstrained<*>.extractSinglePrimitiveProperty(): T {
     val kClass = this::class
-    val allProps = kClass.memberProperties.toList()
+    val allProps =
+        kClass.memberProperties
+            .filterNot { it.name == "schema" }
+            .toList()
+
+    val primaryConstructorProp =
+        kClass.primaryConstructor
+            ?.parameters
+            ?.singleOrNull()
+            ?.name
+            ?.let { ctorParamName -> allProps.find { it.name == ctorParamName } }
+
     val matching = allProps.filter { it.returnType.classifier == T::class }
     val prop =
         when {
+            primaryConstructorProp != null && primaryConstructorProp.returnType.classifier == T::class -> primaryConstructorProp
             matching.size == 1 -> matching[0]
             matching.isEmpty() && allProps.size == 1 -> allProps[0]
             matching.isEmpty() ->


### PR DESCRIPTION
### Motivation
- Tests for primitive-backed `Konstrained` types were failing because the reflection-based extractor could pick up the inherited `schema` property or the wrong backing field, breaking round-trip encode/decode and FlagValue handling.
- The recipes documentation was stale relative to the Kotlin samples and needed regeneration so CI doc verification passes.

### Description
- Update `SchemaValueCodec.extractSinglePrimitiveProperty` to ignore the inherited `schema` property and prefer the primary-constructor-backed property when selecting the single primitive/list backing field, improving robustness for `@JvmInline` value classes and other Konstrained implementations.
- Regenerate `docusaurus/docs/advanced/recipes.md` from the docs samples so the recipes doc matches the samples and CI verification tasks succeed.

### Testing
- Ran `./gradlew :konditional-serialization:test --tests '*KonstrainedPrimitiveTest'` and the targeted tests completed successfully.
- Ran `./gradlew :konditional-observability:generateRecipesDocs` and the generation completed successfully.
- Ran `./gradlew :konditional-observability:verifyRecipesDocs` and verification completed successfully.
- Ran the full `make test` and the test suite completed successfully (previous failing serialization tests are now resolved).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c65309e748329b556c5c731b7cf46)