### PR TITLE
Decouple snapshot publishing from cut-release commits (update snapshot.yml)

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       snapshot-version:
@@ -20,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       snapshot-version: ${{ steps.snapshot-version.outputs.value }}
+      publish-snapshot: ${{ steps.snapshot-version.outputs.publish }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -35,22 +41,40 @@ jobs:
         id: snapshot-version
         run: |
           VERSION="${{ github.event.inputs.snapshot-version }}"
+          REQUIRE_SNAPSHOT=false
+          SHOULD_PUBLISH_SNAPSHOT=false
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            REQUIRE_SNAPSHOT=true
+          fi
 
           if [ -z "$VERSION" ]; then
-            BASE_VERSION="$(grep -E '^(version|VERSION)=' gradle.properties | head -n1 | cut -d'=' -f2)"
-            if [[ "$BASE_VERSION" =~ -SNAPSHOT$ ]]; then
-              VERSION="$BASE_VERSION"
+            if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+              VERSION="${GITHUB_REF_NAME#v}"
             else
-              VERSION="${BASE_VERSION}-SNAPSHOT"
+              BASE_VERSION="$(grep -E '^(version|VERSION)=' gradle.properties | head -n1 | cut -d'=' -f2)"
+              VERSION="$BASE_VERSION"
+
+              if [[ "$REQUIRE_SNAPSHOT" == "true" && ! "$VERSION" =~ -SNAPSHOT$ ]]; then
+                VERSION="${VERSION}-SNAPSHOT"
+              fi
             fi
           fi
 
-          if [[ ! "$VERSION" =~ -SNAPSHOT$ ]]; then
+          if [[ "$REQUIRE_SNAPSHOT" == "true" && ! "$VERSION" =~ -SNAPSHOT$ ]]; then
             echo "ERROR: Version must end with -SNAPSHOT"
             exit 1
           fi
-          echo "✓ Valid snapshot version: $VERSION"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            SHOULD_PUBLISH_SNAPSHOT=true
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF_TYPE}" == "branch" && "${GITHUB_REF_NAME}" == "main" && "$VERSION" =~ -SNAPSHOT$ ]]; then
+            SHOULD_PUBLISH_SNAPSHOT=true
+          fi
+
+          echo "✓ Validated version: $VERSION (publish snapshot: $SHOULD_PUBLISH_SNAPSHOT)"
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "publish=$SHOULD_PUBLISH_SNAPSHOT" >> "$GITHUB_OUTPUT"
 
       - name: Run tests
         env:
@@ -60,6 +84,7 @@ jobs:
   publish-github-packages:
     runs-on: ubuntu-latest
     needs: validate
+    if: needs.validate.outputs.publish-snapshot == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -119,6 +144,7 @@ jobs:
   publish-maven-central:
     runs-on: ubuntu-latest
     needs: validate
+    if: needs.validate.outputs.publish-snapshot == 'true'
     outputs:
       published: ${{ steps.gate.outputs.publish }}
     steps:


### PR DESCRIPTION
### Motivation
- The snapshot workflow was treating all `main` pushes as snapshot-publish intent which caused cut-release commits (temporary non-`-SNAPSHOT` versions) to fail or trigger unwanted publish attempts. 
- The goal is to keep validation/tests running for pushes/PRs/tags while making actual snapshot publishing explicit and conditional.

### Description
- Added `tags` and `pull_request` triggers and made `validate` emit both `snapshot-version` and a new `publish-snapshot` boolean output. 
- Reworked the `Validate snapshot version` step so `-SNAPSHOT` is only strictly required for manual `workflow_dispatch` runs and so tag events derive the release version from the `vX.Y.Z` tag. 
- Computed `SHOULD_PUBLISH_SNAPSHOT` and gated `publish-github-packages` and `publish-maven-central` jobs with `if: needs.validate.outputs.publish-snapshot == 'true'` so publishing runs only when snapshot intent is present. 
- Preserved test execution by running `./gradlew -Pversion="${VERSION}" test --no-daemon` on the resolved version for all validation events. 

### Testing
- Ran `./gradlew test --no-daemon`, which completed successfully. 
- Verified the modified workflow file composes and the `validate` step produces `snapshot-version` and `publish` outputs locally via the `validate` script logic during manual inspection. 
- No CI publish runs were executed in this environment due to missing remote/Secrets, but publish jobs are now conditional and will only run when `publish-snapshot` is `true`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c924de8308329b2d1777ee2f2d88a)