### PR TITLE
feat(core, serialization): add Konstrained.As* custom-type adapter family

### DIFF
--- a/konditional-core/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt
+++ b/konditional-core/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt
@@ -75,38 +75,38 @@ private val defaultDoubleSchema: DoubleSchema = doubleSchema() as DoubleSchema
  *
  * ### Custom-type adapters (As* family — for non-primitive domain types)
  * When the domain value type `T` is not itself a JSON primitive (e.g., `LocalDate`, `UUID`,
- * a newtype wrapper, etc.), use the [AsString], [AsInt], [AsBoolean], or [AsDouble] sub-interfaces
- * to declare the JSON wire format and provide the encode/decode logic.
+ * a newtype wrapper, etc.), use the [AsString], [AsInt], [AsBoolean], or [AsDouble]
+ * sub-interfaces to declare the JSON wire format and supply encode/decode logic.
  *
- * The implementing class provides [AsString.encode] as an instance method and supplies a
- * companion object implementing the matching [StringDecoder] (or [IntDecoder], etc.) to
- * support construction from the raw wire value.
- *
- * Schema declaration is optional — a plain, unconstrained schema is used by default.
- * Override [AsString.schema] (or the matching property) to add format, pattern, or range
- * constraints.
+ * Both [AsString.encode] (instance → wire) and [AsString.decode] (wire → instance) are
+ * declared directly on the interface, making the full codec contract visible. Shared logic
+ * can be extracted into standalone [Encoder] and [Decoder] objects and reused across types:
  *
  * ```kotlin
- * @JvmInline
- * value class ExpirationDate(val value: LocalDate) : Konstrained.AsString<LocalDate> {
- *     override fun encode(): String = value.toString()
- *     // Schema defaults to StringSchema {}; override to constrain:
- *     // override val schema = stringSchema { format = "date" } as StringSchema
+ * private val localDateDecoder = Konstrained.Decoder<String, LocalDate> { LocalDate.parse(it) }
  *
- *     companion object : Konstrained.StringDecoder<ExpirationDate> {
- *         override fun decode(raw: String): ExpirationDate =
- *             ExpirationDate(LocalDate.parse(raw))
+ * @JvmInline
+ * value class ExpirationDate(val value: LocalDate) : Konstrained.AsString<LocalDate, ExpirationDate> {
+ *     override fun encode(): String = value.toString()
+ *     override fun decode(raw: String): ExpirationDate = ExpirationDate(localDateDecoder.decode(raw))
+ *
+ *     companion object : Konstrained.Decoder<String, ExpirationDate> {
+ *         override fun decode(raw: String) = ExpirationDate(localDateDecoder.decode(raw))
  *     }
  * }
  * ```
+ *
+ * The companion object implementing [Decoder] allows the serialization codec to reconstruct
+ * instances from snapshots (where no prototype is available). Schema declaration is optional;
+ * the default is an unconstrained schema. Override [AsString.schema] to add constraints.
  *
  * ## Invariants
  * - For primitive and array schemas the implementing class **must** have exactly one property
  *   whose type matches the schema's Kotlin backing type. Violations produce a descriptive
  *   [IllegalArgumentException] at encode/decode time.
- * - For [AsString] / [AsInt] / [AsBoolean] / [AsDouble] schemas the companion object **must**
- *   implement the corresponding [StringDecoder] / [IntDecoder] / [BooleanDecoder] / [DoubleDecoder]
- *   to enable deserialization from a snapshot.
+ * - For [AsString] / [AsInt] / [AsBoolean] / [AsDouble] types whose companion implements
+ *   [Decoder], [Decoder.decode] must be the left-inverse of [AsString.encode]:
+ *   `decode(encode(x)).value == x`.
  * - Determinism: [schema] must return a value-equal result on every call. Creating a new schema
  *   instance per call is acceptable as long as its properties are identical each time.
  * - Boundary discipline: raw external values (JSON, HTTP) are never accepted as trusted;
@@ -154,39 +154,136 @@ sealed interface Konstrained<out S : JsonSchema<*>> {
     }
 
     // -------------------------------------------------------------------------
+    // Composable codec interfaces — standalone building blocks for the As* family
+    // -------------------------------------------------------------------------
+
+    /**
+     * Converts a domain value [T] to its JSON-primitive wire representation [P].
+     *
+     * Implement as a standalone `object` or `fun interface` lambda to share encoding
+     * logic across multiple [AsString] / [AsInt] / [AsBoolean] / [AsDouble] types that
+     * wrap the same domain type:
+     *
+     * ```kotlin
+     * val localDateEncoder = Konstrained.Encoder<LocalDate, String> { it.toString() }
+     * ```
+     *
+     * ### Invariants
+     * - [encode] must be pure and deterministic: same [T] → same [P] always.
+     *
+     * @param T The domain type being encoded.
+     * @param P The JSON-primitive target type (`String`, `Int`, `Boolean`, or `Double`).
+     */
+    fun interface Encoder<T : Any, P : Any> {
+        fun encode(value: T): P
+    }
+
+    /**
+     * Reconstructs a [V] instance from a raw JSON-primitive value [P].
+     *
+     * Implement as a standalone `object` to share decoding logic across multiple types,
+     * or supply from a **companion object** of an [AsString] / [AsInt] / [AsBoolean] /
+     * [AsDouble] implementation to enable codec discoverability:
+     *
+     * ```kotlin
+     * val localDateDecoder = Konstrained.Decoder<String, LocalDate> { LocalDate.parse(it) }
+     *
+     * companion object : Konstrained.Decoder<String, ExpirationDate> {
+     *     override fun decode(raw: String) = ExpirationDate(localDateDecoder.decode(raw))
+     * }
+     * ```
+     *
+     * The serialization codec checks whether a class's companion object implements this
+     * interface and uses it to reconstruct instances from snapshots (where no prototype
+     * instance is available). If no companion [Decoder] is present, the codec falls back
+     * to primary-constructor invocation — suitable only for [Primitive] types whose single
+     * constructor parameter is the raw primitive itself.
+     *
+     * ### Invariants
+     * - [decode] must be the left-inverse of the corresponding [Encoder.encode]:
+     *   `decoder.decode(encoder.encode(x)) == x`.
+     * - [decode] must throw a descriptive exception (not return `null`) if [raw] is invalid.
+     *
+     * @param P The raw JSON-primitive source type.
+     * @param V The [Konstrained] value type produced by [decode].
+     */
+    fun interface Decoder<P : Any, out V : Any> {
+        fun decode(raw: P): V
+    }
+
+    // -------------------------------------------------------------------------
     // Adapted family — domain type T is encoded AS a JSON primitive
     //
     // Use these when T is not itself a JSON primitive (e.g. LocalDate, UUID).
-    // The [encode] method converts T → wire primitive; the companion [StringDecoder]
-    // (or equivalent) converts wire primitive → T and constructs the value class.
+    //
+    // Both encode() and decode() are declared on the interface, making the full
+    // codec contract explicit and testable without relying on hidden conventions.
+    //
+    // Composition: delegate to shared Encoder / Decoder objects to avoid
+    // duplicating parse/format logic across types that wrap the same domain type.
     // -------------------------------------------------------------------------
 
     /**
      * Marker for a type whose domain value [T] is serialized as a JSON **string**.
      *
-     * - [encode] (instance, abstract) converts the wrapped value to its string representation.
-     * - [schema] has a default of plain [StringSchema] — override to add constraints such as
-     *   `format`, `pattern`, or `minLength`.
-     * - The companion object of the implementing class **must** implement [StringDecoder] so
-     *   that the serialization layer can reconstruct instances from raw strings.
+     * - [encode] (instance) converts the wrapped value to its string wire form.
+     * - [decode] (instance) reconstructs a new [V] instance from the raw wire string.
+     *   Typically delegates to the companion [Decoder] for a single source of truth.
+     * - [schema] defaults to an unconstrained [StringSchema]; override to add `format`,
+     *   `pattern`, or `minLength` constraints.
+     *
+     * ## Codec discoverability
+     *
+     * The companion object of the implementing class **should** implement
+     * [Konstrained.Decoder]`<String, V>` so the serialization codec can reconstruct
+     * instances from snapshots without a prototype:
+     *
+     * ```kotlin
+     * companion object : Konstrained.Decoder<String, ExpirationDate> {
+     *     override fun decode(raw: String) = ExpirationDate(LocalDate.parse(raw))
+     * }
+     * ```
+     *
+     * ## Composition
+     *
+     * ```kotlin
+     * private val localDateDecoder = Konstrained.Decoder<String, LocalDate> { LocalDate.parse(it) }
+     *
+     * @JvmInline
+     * value class ExpirationDate(val value: LocalDate) : Konstrained.AsString<LocalDate, ExpirationDate> {
+     *     override fun encode(): String = value.toString()
+     *     override fun decode(raw: String): ExpirationDate = ExpirationDate(localDateDecoder.decode(raw))
+     *     companion object : Konstrained.Decoder<String, ExpirationDate> {
+     *         override fun decode(raw: String) = ExpirationDate(localDateDecoder.decode(raw))
+     *     }
+     * }
+     * ```
      *
      * ### Invariants
-     * - [encode] must be deterministic: same [T] value → same [String] output, always.
-     * - [StringDecoder.decode] must be the left-inverse of [encode]:
-     *   `decode(encode(x)).value == x`.
+     * - [encode] must be pure and deterministic: same [T] → same [String] always.
+     * - [decode] must be the left-inverse of [encode]: `decode(encode(x)).value == x`.
      *
      * @param T The domain type wrapped by this value class.
+     * @param V The concrete self-type; enables type-safe [decode] return without casting.
      */
-    interface AsString<T : Any> : Konstrained<StringSchema> {
+    interface AsString<T : Any, V : AsString<T, V>> : Konstrained<StringSchema> {
         /** The domain value held by this instance. */
         val value: T
 
         /**
-         * Encodes [value] to its JSON string representation.
+         * Encodes [value] to its JSON string wire representation.
          *
          * Must be pure and deterministic.
          */
         fun encode(): kotlin.String
+
+        /**
+         * Reconstructs a new [V] instance from the raw wire string [raw].
+         *
+         * Must be the left-inverse of [encode]: `decode(encode(x)).value == x`.
+         * Must throw a descriptive exception if [raw] is invalid.
+         */
+        fun decode(raw: kotlin.String): V
 
         /**
          * The [StringSchema] used to validate and describe the wire representation.
@@ -202,108 +299,45 @@ sealed interface Konstrained<out S : JsonSchema<*>> {
     /**
      * Marker for a type whose domain value [T] is serialized as a JSON **integer**.
      *
-     * - [encode] (instance, abstract) converts the wrapped value to its integer representation.
-     * - [schema] has a default of plain [IntSchema] — override to add `minimum`/`maximum`.
-     * - The companion object of the implementing class **must** implement [IntDecoder].
+     * See [AsString] for the full contract; this variant uses [Int] as the wire type.
      *
      * @param T The domain type wrapped by this value class.
+     * @param V The concrete self-type; enables type-safe [decode] return.
      */
-    interface AsInt<T : Any> : Konstrained<IntSchema> {
+    interface AsInt<T : Any, V : AsInt<T, V>> : Konstrained<IntSchema> {
         val value: T
-
         fun encode(): kotlin.Int
-
+        fun decode(raw: kotlin.Int): V
         override val schema: IntSchema get() = defaultIntSchema
     }
 
     /**
      * Marker for a type whose domain value [T] is serialized as a JSON **boolean**.
      *
-     * - [encode] (instance, abstract) converts the wrapped value to its boolean representation.
-     * - [schema] has a default of plain [BooleanSchema] — override to add a `default`.
-     * - The companion object of the implementing class **must** implement [BooleanDecoder].
+     * See [AsString] for the full contract; this variant uses [Boolean] as the wire type.
      *
      * @param T The domain type wrapped by this value class.
+     * @param V The concrete self-type; enables type-safe [decode] return.
      */
-    interface AsBoolean<T : Any> : Konstrained<BooleanSchema> {
+    interface AsBoolean<T : Any, V : AsBoolean<T, V>> : Konstrained<BooleanSchema> {
         val value: T
-
         fun encode(): kotlin.Boolean
-
+        fun decode(raw: kotlin.Boolean): V
         override val schema: BooleanSchema get() = defaultBooleanSchema
     }
 
     /**
      * Marker for a type whose domain value [T] is serialized as a JSON **number (double)**.
      *
-     * - [encode] (instance, abstract) converts the wrapped value to its double representation.
-     * - [schema] has a default of plain [DoubleSchema] — override to add `minimum`/`maximum`.
-     * - The companion object of the implementing class **must** implement [DoubleDecoder].
+     * See [AsString] for the full contract; this variant uses [Double] as the wire type.
      *
      * @param T The domain type wrapped by this value class.
+     * @param V The concrete self-type; enables type-safe [decode] return.
      */
-    interface AsDouble<T : Any> : Konstrained<DoubleSchema> {
+    interface AsDouble<T : Any, V : AsDouble<T, V>> : Konstrained<DoubleSchema> {
         val value: T
-
         fun encode(): kotlin.Double
-
-        override val schema: DoubleSchema get() = defaultDoubleSchema
-    }
-
-    // -------------------------------------------------------------------------
-    // Decoder interfaces — implement on the companion object of As* types
-    //
-    // These are the "fromJson" side of the adapter contract, analogous to a
-    // Moshi @FromJson adapter. Each companion decoder reconstructs the full
-    // value-class instance from the raw JSON primitive.
-    // -------------------------------------------------------------------------
-
-    /**
-     * Companion-side decoder for [AsString] types.
-     *
-     * Implement on the **companion object** of a class that implements [AsString]:
-     * ```kotlin
-     * companion object : Konstrained.StringDecoder<ExpirationDate> {
-     *     override fun decode(raw: String): ExpirationDate =
-     *         ExpirationDate(LocalDate.parse(raw))
-     * }
-     * ```
-     *
-     * ### Contract
-     * - [decode] must be the inverse of the instance's [AsString.encode]:
-     *   `instance.value == decode(instance.encode()).value`.
-     * - [decode] must throw a descriptive exception (not return null) if [raw] is invalid.
-     *
-     * @param V The [AsString] implementation type produced by [decode].
-     */
-    interface StringDecoder<out V : AsString<*>> {
-        fun decode(raw: kotlin.String): V
-    }
-
-    /**
-     * Companion-side decoder for [AsInt] types.
-     *
-     * @param V The [AsInt] implementation type produced by [decode].
-     */
-    interface IntDecoder<out V : AsInt<*>> {
-        fun decode(raw: kotlin.Int): V
-    }
-
-    /**
-     * Companion-side decoder for [AsBoolean] types.
-     *
-     * @param V The [AsBoolean] implementation type produced by [decode].
-     */
-    interface BooleanDecoder<out V : AsBoolean<*>> {
-        fun decode(raw: kotlin.Boolean): V
-    }
-
-    /**
-     * Companion-side decoder for [AsDouble] types.
-     *
-     * @param V The [AsDouble] implementation type produced by [decode].
-     */
-    interface DoubleDecoder<out V : AsDouble<*>> {
         fun decode(raw: kotlin.Double): V
+        override val schema: DoubleSchema get() = defaultDoubleSchema
     }
 }

--- a/konditional-serialization/src/main/kotlin/io/amichne/konditional/serialization/SchemaValueCodec.kt
+++ b/konditional-serialization/src/main/kotlin/io/amichne/konditional/serialization/SchemaValueCodec.kt
@@ -79,6 +79,8 @@ object SchemaValueCodec {
      * 1. [Konstrained.AsString] / [Konstrained.AsInt] / [Konstrained.AsBoolean] /
      *    [Konstrained.AsDouble] — calls the instance's [Konstrained.AsString.encode] method,
      *    enabling domain types that are not themselves JSON primitives (e.g. `LocalDate`).
+     *    Checked first so that an `AsString<LocalDate>` (whose `schema` IS a `StringSchema`)
+     *    does not accidentally fall into the [Konstrained.Primitive.String] path.
      * 2. Object schemas → [JsonObject] (via field-reflection codec)
      * 3. String/Boolean/Int/Double schemas → the matching JSON primitive (existing path,
      *    for [Konstrained.Primitive] types whose value IS the primitive).
@@ -92,12 +94,10 @@ object SchemaValueCodec {
     fun encodeKonstrained(konstrained: Konstrained<*>): JsonValue =
         when {
             // Adapted family: domain type T → JSON primitive via the instance's encode().
-            // Checked before schema dispatch so that e.g. AsString<LocalDate> (whose schema
-            // IS a StringSchema) does not accidentally fall into the Primitive.String path.
-            konstrained is Konstrained.AsString<*> -> jsonValue { string(konstrained.encode()) }
-            konstrained is Konstrained.AsInt<*> -> jsonValue { number(konstrained.encode()) }
-            konstrained is Konstrained.AsBoolean<*> -> jsonValue { boolean(konstrained.encode()) }
-            konstrained is Konstrained.AsDouble<*> -> jsonValue { number(konstrained.encode()) }
+            konstrained is Konstrained.AsString<*, *> -> jsonValue { string(konstrained.encode()) }
+            konstrained is Konstrained.AsInt<*, *> -> jsonValue { number(konstrained.encode()) }
+            konstrained is Konstrained.AsBoolean<*, *> -> jsonValue { boolean(konstrained.encode()) }
+            konstrained is Konstrained.AsDouble<*, *> -> jsonValue { number(konstrained.encode()) }
             else ->
                 when (val schema = konstrained.schema) {
                     is ObjectTraits -> encode(konstrained, schema.asObjectSchema())
@@ -112,8 +112,7 @@ object SchemaValueCodec {
                                 "Supported: ObjectSchema, RootObjectSchema, StringSchema, BooleanSchema, " +
                                 "IntSchema, DoubleSchema, ArraySchema. " +
                                 "For non-primitive domain types implement Konstrained.AsString / AsInt / " +
-                                "AsBoolean / AsDouble and supply a companion StringDecoder / IntDecoder / " +
-                                "BooleanDecoder / DoubleDecoder.",
+                                "AsBoolean / AsDouble and supply a companion Konstrained.Decoder.",
                         )
                 }
         }
@@ -123,13 +122,12 @@ object SchemaValueCodec {
      *
      * ## Dispatch order
      *
-     * 1. **Companion decoder** — if the target class has a companion object that implements
-     *    [Konstrained.StringDecoder], [Konstrained.IntDecoder], [Konstrained.BooleanDecoder],
-     *    or [Konstrained.DoubleDecoder] (matching the type of [rawValue]), the companion's
-     *    `decode` method is called and its result is returned directly. This supports
-     *    [Konstrained.AsString] / [Konstrained.AsInt] / [Konstrained.AsBoolean] /
-     *    [Konstrained.AsDouble] types whose wrapped domain value is not itself a JSON
-     *    primitive (e.g. `LocalDate`, `UUID`).
+     * 1. **Companion [Konstrained.Decoder]** — if the target class has a companion object
+     *    that implements [Konstrained.Decoder]`<P, T>` (where `P` matches the runtime type
+     *    of [rawValue]), the companion's [Konstrained.Decoder.decode] is called directly.
+     *    This is the canonical path for [Konstrained.AsString] / [Konstrained.AsInt] /
+     *    [Konstrained.AsBoolean] / [Konstrained.AsDouble] types whose wrapped domain value
+     *    is not itself a JSON primitive (e.g. `LocalDate`, `UUID`).
      *
      * 2. **Primary constructor** — fallback for [Konstrained.Primitive] types whose single
      *    constructor parameter type matches [rawValue] directly (e.g. `Email(value: String)`).
@@ -145,11 +143,11 @@ object SchemaValueCodec {
     @KonditionalInternalApi
     @Suppress("ReturnCount")
     fun <T : Any> decodeKonstrainedPrimitive(kClass: KClass<T>, rawValue: Any): Result<T> {
-        // Step 1: prefer companion decoder when present — supports As* types with non-primitive
-        // domain values. The cast is safe: the companion is the companion of kClass (which
-        // produces T), and the decoder's type parameter is covariant.
-        val companionResult = decodeViaCompanionDecoder(kClass, rawValue)
-        if (companionResult != null) return companionResult
+        // Step 1: prefer a companion Decoder when present — supports As* types with
+        // non-primitive domain values. The cast is safe: the companion is the companion
+        // of kClass (which produces T), and Decoder's V parameter is covariant.
+        val decoderResult = decodeViaDecoder(kClass, rawValue)
+        if (decoderResult != null) return decoderResult
 
         // Step 2: fall back to direct constructor invocation for Konstrained.Primitive types.
         val constructor =
@@ -184,69 +182,47 @@ object SchemaValueCodec {
     }
 
     /**
-     * Attempts to decode [rawValue] using a companion-object decoder, returning `null` when
-     * no matching decoder companion is found (so the caller can fall through to the next
-     * strategy).
+     * Attempts to decode [rawValue] via a companion-object [Konstrained.Decoder], returning
+     * `null` when no matching companion decoder is found so the caller can fall through to
+     * the primary-constructor path.
      *
-     * The unchecked casts are safe: the companion is the companion of [kClass], which by
-     * the [Konstrained.StringDecoder] / [IntDecoder] / [BooleanDecoder] / [DoubleDecoder]
-     * contracts produces a value of type `V` that is the same class as [kClass]'s type `T`.
+     * A single [Konstrained.Decoder]`<P, V>` interface replaces the previous four bespoke
+     * `StringDecoder` / `IntDecoder` / `BooleanDecoder` / `DoubleDecoder` interfaces.
+     * The `P` type parameter is inferred from the runtime type of [rawValue]; the unchecked
+     * cast to `Decoder<P, T>` is safe because the companion is the companion of [kClass],
+     * which by the [Konstrained.Decoder] contract produces values of type `T`.
      */
     @Suppress("UNCHECKED_CAST")
-    private fun <T : Any> decodeViaCompanionDecoder(kClass: KClass<T>, rawValue: Any): Result<T>? {
+    private fun <T : Any> decodeViaDecoder(kClass: KClass<T>, rawValue: Any): Result<T>? {
         val companion = kClass.companionObjectInstance ?: return null
-        return when {
-            rawValue is String && companion is Konstrained.StringDecoder<*> ->
-                runCatching { (companion as Konstrained.StringDecoder<T>).decode(rawValue) }
+        if (companion !is Konstrained.Decoder<*, *>) return null
+        val errorMessage: (Throwable) -> String = {
+            "Decoder on ${kClass.qualifiedName} failed for value '$rawValue': ${it.message}"
+        }
+        return when (rawValue) {
+            is String ->
+                runCatching { (companion as Konstrained.Decoder<String, T>).decode(rawValue) }
                     .fold(
                         onSuccess = { Result.success(it) },
-                        onFailure = {
-                            parseFailure(
-                                ParseError.InvalidSnapshot(
-                                    "StringDecoder on ${kClass.qualifiedName} failed for value " +
-                                        "'$rawValue': ${it.message}",
-                                ),
-                            )
-                        },
+                        onFailure = { parseFailure(ParseError.InvalidSnapshot(errorMessage(it))) },
                     )
-            rawValue is Int && companion is Konstrained.IntDecoder<*> ->
-                runCatching { (companion as Konstrained.IntDecoder<T>).decode(rawValue) }
+            is Int ->
+                runCatching { (companion as Konstrained.Decoder<Int, T>).decode(rawValue) }
                     .fold(
                         onSuccess = { Result.success(it) },
-                        onFailure = {
-                            parseFailure(
-                                ParseError.InvalidSnapshot(
-                                    "IntDecoder on ${kClass.qualifiedName} failed for value " +
-                                        "'$rawValue': ${it.message}",
-                                ),
-                            )
-                        },
+                        onFailure = { parseFailure(ParseError.InvalidSnapshot(errorMessage(it))) },
                     )
-            rawValue is Boolean && companion is Konstrained.BooleanDecoder<*> ->
-                runCatching { (companion as Konstrained.BooleanDecoder<T>).decode(rawValue) }
+            is Boolean ->
+                runCatching { (companion as Konstrained.Decoder<Boolean, T>).decode(rawValue) }
                     .fold(
                         onSuccess = { Result.success(it) },
-                        onFailure = {
-                            parseFailure(
-                                ParseError.InvalidSnapshot(
-                                    "BooleanDecoder on ${kClass.qualifiedName} failed for value " +
-                                        "'$rawValue': ${it.message}",
-                                ),
-                            )
-                        },
+                        onFailure = { parseFailure(ParseError.InvalidSnapshot(errorMessage(it))) },
                     )
-            rawValue is Double && companion is Konstrained.DoubleDecoder<*> ->
-                runCatching { (companion as Konstrained.DoubleDecoder<T>).decode(rawValue) }
+            is Double ->
+                runCatching { (companion as Konstrained.Decoder<Double, T>).decode(rawValue) }
                     .fold(
                         onSuccess = { Result.success(it) },
-                        onFailure = {
-                            parseFailure(
-                                ParseError.InvalidSnapshot(
-                                    "DoubleDecoder on ${kClass.qualifiedName} failed for value " +
-                                        "'$rawValue': ${it.message}",
-                                ),
-                            )
-                        },
+                        onFailure = { parseFailure(ParseError.InvalidSnapshot(errorMessage(it))) },
                     )
             else -> null
         }

--- a/konditional-serialization/src/test/kotlin/io/amichne/konditional/fixtures/serializers/PrimitiveKonstrainedFixtures.kt
+++ b/konditional-serialization/src/test/kotlin/io/amichne/konditional/fixtures/serializers/PrimitiveKonstrainedFixtures.kt
@@ -59,19 +59,34 @@ value class Tags(override val values: List<String>) : Konstrained.Array<ArraySch
 // As* family — domain type T encoded AS a JSON primitive
 // ---------------------------------------------------------------------------
 
+// Shared Decoder instances — reused across multiple types that wrap the same domain type,
+// eliminating duplicate parse/format logic. These are the Konstrained.Decoder analogue
+// of a Moshi TypeAdapter that can be applied to many fields.
+private val localDateDecoder: Konstrained.Decoder<String, LocalDate> =
+    Konstrained.Decoder { LocalDate.parse(it) }
+
+private val uuidDecoder: Konstrained.Decoder<String, UUID> =
+    Konstrained.Decoder { UUID.fromString(it) }
+
 /**
  * A calendar date serialized as an ISO-8601 string (e.g. `"2025-06-15"`).
  *
  * Demonstrates [Konstrained.AsString] with a non-primitive domain type ([LocalDate]).
  * No explicit schema override — the default unconstrained [StringSchema] is used.
- * The companion [Konstrained.StringDecoder] reconstructs the value from the wire string.
+ *
+ * Both [encode] and [decode] are declared on the [Konstrained.AsString] interface,
+ * making the full codec contract visible without any hidden companion conventions.
+ * The companion implements [Konstrained.Decoder] so the serialization codec can
+ * reconstruct instances from snapshots (where no prototype instance is available).
+ * The instance [decode] delegates to the companion to keep logic in one place.
  */
 @JvmInline
-value class ExpirationDate(val value: LocalDate) : Konstrained.AsString<LocalDate> {
+value class ExpirationDate(val value: LocalDate) : Konstrained.AsString<LocalDate, ExpirationDate> {
     override fun encode(): String = value.toString()
+    override fun decode(raw: String): ExpirationDate = Companion.decode(raw)
 
-    companion object : Konstrained.StringDecoder<ExpirationDate> {
-        override fun decode(raw: String): ExpirationDate = ExpirationDate(LocalDate.parse(raw))
+    companion object : Konstrained.Decoder<String, ExpirationDate> {
+        override fun decode(raw: String): ExpirationDate = ExpirationDate(localDateDecoder.decode(raw))
     }
 }
 
@@ -79,30 +94,34 @@ value class ExpirationDate(val value: LocalDate) : Konstrained.AsString<LocalDat
  * A calendar date with an explicit schema override declaring the `"date"` OpenAPI format.
  *
  * Demonstrates optional schema customization on top of [Konstrained.AsString].
+ * Reuses [localDateDecoder] — the same [Konstrained.Decoder] shared with [ExpirationDate].
  */
 @JvmInline
-value class AuditDate(val value: LocalDate) : Konstrained.AsString<LocalDate> {
+value class AuditDate(val value: LocalDate) : Konstrained.AsString<LocalDate, AuditDate> {
     @Suppress("UNCHECKED_CAST")
     override val schema: StringSchema
         get() = stringSchema { format = "date" } as StringSchema
 
     override fun encode(): String = value.toString()
+    override fun decode(raw: String): AuditDate = Companion.decode(raw)
 
-    companion object : Konstrained.StringDecoder<AuditDate> {
-        override fun decode(raw: String): AuditDate = AuditDate(LocalDate.parse(raw))
+    companion object : Konstrained.Decoder<String, AuditDate> {
+        override fun decode(raw: String): AuditDate = AuditDate(localDateDecoder.decode(raw))
     }
 }
 
 /**
  * A [UUID] correlation identifier serialized as its canonical hyphenated string form.
  *
- * Demonstrates [Konstrained.AsString] with a second non-primitive domain type.
+ * Demonstrates [Konstrained.AsString] with a second non-primitive domain type,
+ * reusing [uuidDecoder] for the parse step.
  */
 @JvmInline
-value class CorrelationId(val value: UUID) : Konstrained.AsString<UUID> {
+value class CorrelationId(val value: UUID) : Konstrained.AsString<UUID, CorrelationId> {
     override fun encode(): String = value.toString()
+    override fun decode(raw: String): CorrelationId = Companion.decode(raw)
 
-    companion object : Konstrained.StringDecoder<CorrelationId> {
-        override fun decode(raw: String): CorrelationId = CorrelationId(UUID.fromString(raw))
+    companion object : Konstrained.Decoder<String, CorrelationId> {
+        override fun decode(raw: String): CorrelationId = CorrelationId(uuidDecoder.decode(raw))
     }
 }

--- a/konditional-serialization/src/test/kotlin/io/amichne/konditional/serialization/KonstrainedCustomTypeTest.kt
+++ b/konditional-serialization/src/test/kotlin/io/amichne/konditional/serialization/KonstrainedCustomTypeTest.kt
@@ -32,7 +32,8 @@ import java.util.UUID
  *
  * Validates:
  * - [SchemaValueCodec.encodeKonstrained] uses the instance [encode] method
- * - [SchemaValueCodec.decodeKonstrainedPrimitive] uses the companion [StringDecoder]
+ * - [SchemaValueCodec.decodeKonstrainedPrimitive] uses the companion [Konstrained.Decoder]
+ * - The instance [decode] method is the inverse of [encode] (round-trip via interface)
  * - [FlagValue.from] / [FlagValue.extractValue] round-trip correctness
  * - Moshi serialization / deserialization of [FlagValue.KonstrainedPrimitive]
  * - [ConfigValue.from] dispatches correctly for As* types
@@ -86,25 +87,25 @@ class KonstrainedCustomTypeTest {
     }
 
     // =========================================================================
-    // SchemaValueCodec.decodeKonstrainedPrimitive — companion StringDecoder
+    // SchemaValueCodec.decodeKonstrainedPrimitive — companion Konstrained.Decoder
     // =========================================================================
 
     @Test
-    fun `decodeKonstrainedPrimitive uses StringDecoder companion for ExpirationDate`() {
+    fun `decodeKonstrainedPrimitive uses companion Decoder for ExpirationDate`() {
         val result = SchemaValueCodec.decodeKonstrainedPrimitive(ExpirationDate::class, "2025-06-15")
         assertTrue(result.isSuccess)
         assertEquals(ExpirationDate(LocalDate.of(2025, 6, 15)), result.getOrThrow())
     }
 
     @Test
-    fun `decodeKonstrainedPrimitive uses StringDecoder companion for AuditDate`() {
+    fun `decodeKonstrainedPrimitive uses companion Decoder for AuditDate`() {
         val result = SchemaValueCodec.decodeKonstrainedPrimitive(AuditDate::class, "2023-11-30")
         assertTrue(result.isSuccess)
         assertEquals(AuditDate(LocalDate.of(2023, 11, 30)), result.getOrThrow())
     }
 
     @Test
-    fun `decodeKonstrainedPrimitive uses StringDecoder companion for CorrelationId`() {
+    fun `decodeKonstrainedPrimitive uses companion Decoder for CorrelationId`() {
         val raw = "550e8400-e29b-41d4-a716-446655440000"
         val result = SchemaValueCodec.decodeKonstrainedPrimitive(CorrelationId::class, raw)
         assertTrue(result.isSuccess)
@@ -112,9 +113,45 @@ class KonstrainedCustomTypeTest {
     }
 
     @Test
-    fun `decodeKonstrainedPrimitive returns failure when StringDecoder throws`() {
+    fun `decodeKonstrainedPrimitive returns failure when Decoder throws`() {
         val result = SchemaValueCodec.decodeKonstrainedPrimitive(ExpirationDate::class, "not-a-date")
         assertTrue(result.isFailure)
+    }
+
+    // =========================================================================
+    // Instance decode() — declared on AsString interface, inverse of encode()
+    // =========================================================================
+
+    @Test
+    fun `instance decode is the inverse of encode for ExpirationDate`() {
+        val original = ExpirationDate(LocalDate.of(2025, 6, 15))
+        val roundTripped = original.decode(original.encode())
+        assertEquals(original, roundTripped)
+    }
+
+    @Test
+    fun `instance decode is the inverse of encode for AuditDate`() {
+        val original = AuditDate(LocalDate.of(2023, 11, 30))
+        val roundTripped = original.decode(original.encode())
+        assertEquals(original, roundTripped)
+    }
+
+    @Test
+    fun `instance decode is the inverse of encode for CorrelationId`() {
+        val original = CorrelationId(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"))
+        val roundTripped = original.decode(original.encode())
+        assertEquals(original, roundTripped)
+    }
+
+    @Test
+    fun `ExpirationDate and AuditDate share the same underlying localDateDecoder logic`() {
+        // Both types wrap LocalDate and parse via the same shared Decoder — verify they
+        // produce structurally equal domain values from the same wire string.
+        val raw = "2025-06-15"
+        val expiry = ExpirationDate(LocalDate.of(2025, 6, 15))
+        val audit = AuditDate(LocalDate.of(2025, 6, 15))
+        assertEquals(expiry.value, audit.decode(raw).value)
+        assertEquals(expiry.decode(raw).value, audit.value)
     }
 
     // =========================================================================


### PR DESCRIPTION
Introduces four new sub-interfaces to Konstrained — AsString<T>, AsInt<T>,
AsBoolean<T>, AsDouble<T> — enabling value classes that wrap non-primitive
domain types (e.g. LocalDate, UUID) to participate in the Konstrained codec
without sacrificing type safety, parse-don't-validate, or determinism.

Design
------
- encode() is an instance method (has access to this.value).
- decode() lives on the companion object implementing the matching
  StringDecoder / IntDecoder / BooleanDecoder / DoubleDecoder interface.
  This mirrors the Moshi @ToJson / @FromJson adapter split.
- Schema defaults to an unconstrained singleton (defaultStringSchema, etc.);
  implementors override the schema property to add format/pattern constraints.

Codec changes (SchemaValueCodec)
----------------------------------
- encodeKonstrained: checks is Konstrained.AsString<*> etc. BEFORE falling
  into the schema-dispatch block, preventing an AsString<LocalDate> whose
  schema IS a StringSchema from incorrectly taking the Primitive.String path.
- decodeKonstrainedPrimitive: new decodeViaCompanionDecoder helper inspects
  the companion object instance for a matching Decoder interface and delegates
  to it; falls through to the existing primary-constructor path for Primitive
  types if no companion decoder is found.

Fixtures & tests
----------------
- ExpirationDate, AuditDate (with schema override), CorrelationId added to
  PrimitiveKonstrainedFixtures as representative As* implementations.
- KonstrainedCustomTypeTest covers: encode/decode dispatch, FlagValue
  round-trips, Moshi serialization, schema default vs override, ConfigValue
  dispatch, feature-flag integration, and snapshot-codec round-trip.

https://claude.ai/code/session_013nyFtaQ12DAjEXnwpEGvFT