### PR TITLE
feat: custom type serialization improvements and feature evaluation maangement + contextual scoping

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -8,7 +8,8 @@ repositories {
 }
 
 dependencies {
-    implementation(libs.kotlin.gradle.plugin)
-    implementation(libs.detekt.gradle.plugin)
-    implementation(libs.vanniktech.maven.publish.plugin)
+    api(libs.kotlin.gradle.plugin)
+    api(libs.detekt.gradle.plugin)
+    api(libs.vanniktech.maven.publish.plugin)
+    testImplementation(libs.junit.jupiter)
 }

--- a/build-logic/src/test/kotlin/io/amichne/konditional/gradle/PublishingConventionsTest.kt
+++ b/build-logic/src/test/kotlin/io/amichne/konditional/gradle/PublishingConventionsTest.kt
@@ -1,7 +1,7 @@
 package io.amichne.konditional.gradle
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class PublishingConventionsTest {
     @Test

--- a/docusaurus/docs/index.md
+++ b/docusaurus/docs/index.md
@@ -1,272 +1,56 @@
 ---
 slug: /
+title: Konditional
+sidebar_position: 0
 ---
 
-# What is Konditional?
+# Konditional
 
-Konditional is a compile-time safe feature flag library for Kotlin that treats flags as typed properties instead of
-runtime strings, and makes configuration a first-class, verifiable contract.
+Typed, deterministic feature management for Kotlin applications with explicit JSON trust boundaries.
 
-## The Problem
+## Why Teams Adopt It
 
-Configuration and feature flags are not "just another component." They are your production control plane, your
-experimentation engine, your insight driver, and your blast-radius minimizer. When everything else goes wrong, this is
-the system you rely on to react safely. That means *certainty* is not a nice-to-have. It is a hard requirement. There is
-no other system where you can afford silent failure less.
+- Compile-time-safe declarations (`Namespace`, `Feature`, typed values).
+- Deterministic evaluation and rollout behavior.
+- Result-based boundary parsing with typed failure semantics.
+- Namespace-scoped runtime operations and rollback controls.
 
-:::danger Key argument
-If you cannot trust your configuration and experimentation engine with absolute certainty, you do not have real control
-in production. That is not a tolerable risk.
-:::
+## Fast Path
 
-Feature flags and configuration systems are often deceptively simple — until they bite you in production:
+1. [Start Here](/overview/start-here)
+2. [Quickstart](/quickstart/)
+3. [First Success Map](/overview/first-success-map)
 
-### String-keyed systems fail silently
-
-Somewhere in onboarding code:
-```kotlin
-val newFlow = flagClient.getBool("new_onboaring_flow", false)  // typo
-```
-
-Somewhere in config JSON:
-```json
-{ "new_onboarding_flow": true }
-```
-
-The typo ships. The flag never activates. Your A/B test runs with 0% treatment. You find out in a post-mortem.
-
-**String keys fail silently.** The compiler can't help you. Your IDE can't help you. And the worst part is you often
-don't even know you are wrong. If you observe one failure, you can't know the full blast radius or the unseen drift.
-That is an intolerable risk for a control plane.
-
-### Boolean-only systems turn into boolean matrices
+## Core Example
 
 ```kotlin
-enum class Capability {
-    NEW_CHECKOUT,
-    NEW_CHECKOUT_V2,
-    NEW_CHECKOUT_V3,
-    CHECKOUT_FAST_PATH
+import io.amichne.konditional.api.evaluate
+import io.amichne.konditional.context.AppLocale
+import io.amichne.konditional.context.Context
+import io.amichne.konditional.context.Platform
+import io.amichne.konditional.context.Version
+import io.amichne.konditional.core.Namespace
+import io.amichne.konditional.core.id.StableId
+
+enum class CheckoutVariant { CLASSIC, SMART }
+
+object AppFeatures : Namespace("app") {
+  val checkoutVariant by enum<CheckoutVariant, Context>(default = CheckoutVariant.CLASSIC)
 }
 
-// Your code becomes:
-if (isEnabled(NEW_CHECKOUT) && !isEnabled(NEW_CHECKOUT_V2)) {
-    // original new checkout
-} else if (isEnabled(NEW_CHECKOUT_V2) && !isEnabled(CHECKOUT_FAST_PATH)) {
-    // v2 without fast path
-}
+val ctx = Context(
+  locale = AppLocale.UNITED_STATES,
+  platform = Platform.IOS,
+  appVersion = Version.of(2, 0, 0),
+  stableId = StableId.of("user-123"),
+)
+
+val variant = AppFeatures.checkoutVariant.evaluate(ctx)
 ```
 
-**Boolean-only forces you to encode variants as control flow.** Testing becomes exponential. Bugs hide in interactions.
-Even moderately complex mappings explode into a fragile web of conditionals. That's not a scaling path; it's a failure
-mode.
+## Navigate by Intent
 
-### Type safety disappears at the boundary
-
-You define this:
-```kotlin
-val maxRetries: Int = flagClient.getInt("max_retries", 3)
-```
-
-Someone deploys this:
-```json5
-{ "max_retries": "5" }
-```
-
-Production gets this:
-```kotlin
-maxRetries = 0  // or throws, or returns default (SDK-dependent)
-```
-
-**Runtime configuration breaks compile-time contracts.** The gap causes incidents.
-
----
-
-## What Konditional Does
-
-Konditional makes three structural commitments:
-
-1. **Flags are properties, not strings** — keys bound at compile-time
-2. **Types flow from definitions to callsites** — no runtime coercion
-3. **One evaluation semantics** — centralized, deterministic, testable
-
-```kotlin
-enum class CheckoutVariant { CLASSIC, OPTIMIZED, EXPERIMENTAL }
-
-object AppFlags : Namespace("app") {
-  val checkoutVariant by enum<CheckoutVariant, Context>(default = CheckoutVariant.CLASSIC) {
-    rule(CheckoutVariant.OPTIMIZED) { ios() }
-    rule(CheckoutVariant.EXPERIMENTAL) { rampUp { 50.0 } }
-  }
-
-  val maxRetries by integer<Context>(default = 3) {
-    rule(5) { android() }
-  }
-}
-
-// Usage
-val variant: CheckoutVariant = AppFlags.checkoutVariant.evaluate(ctx)  // typed
-val retries: Int = AppFlags.maxRetries.evaluate(ctx)                   // typed
-```
-
-### What You Get
-
-**Typos become compile errors:**
-
-```kotlin
-AppFlags.NEW_ONBOARING_FLOW  // doesn't compile
-```
-
-**Type mismatches become compile errors:**
-
-```kotlin
-val retries: String = AppFlags.maxRetries.evaluate(ctx)  // doesn't compile
-```
-
-**Variants are values, not boolean matrices:**
-
-```kotlin
-when (AppFlags.checkoutVariant.evaluate(ctx)) {
-  CheckoutVariant.CLASSIC -> classicCheckout()
-  CheckoutVariant.OPTIMIZED -> optimizedCheckout()
-  CheckoutVariant.EXPERIMENTAL -> experimentalCheckout()
-}
-```
-
-**Ramp-ups are deterministic:**
-
-```kotlin
-// Same user, same flag → same bucket
-// SHA-256("$salt:$flagKey:${stableId.hexId}") determines bucket
-// Reproducible in logs, no random numbers
-```
-
-**Configuration boundaries are explicit:**
-
-```kotlin
-when (val result = NamespaceSnapshotLoader(AppFlags).load(remoteConfig)) {
-  is ParseResult.Success -> Unit // loaded into AppFlags
-  is ParseResult.Failure -> {
-    // Invalid JSON rejected, last-known-good remains active
-    logError("Config parse failed: ${result.error}")
-  }
-}
-```
-
----
-
-## Comparison to Alternatives
-
-| Aspect | String-keyed SDKs | Enum + boolean | Konditional |
-|---|---|---|---|
-| **Typo safety** | Runtime failure (silent or crash) | Compile-time | Compile-time |
-| **Type safety** | Runtime coercion (often unsafe) | Boolean only | Compile-time types |
-| **Variants** | Runtime-typed | Multiple booleans + control flow | First-class typed values |
-| **Ramp-up logic** | SDK-dependent | Per-team reimplementation | Centralized, deterministic |
-| **Evaluation** | SDK-defined, opaque | Ad-hoc per evaluator | Single DSL with specificity |
-| **Invalid config** | Fails silently or crashes | Depends on implementation | Explicit `ParseResult` boundary |
-| **Testing** | Mock SDK or replay snapshots | Mock evaluators | Evaluate against typed contexts |
-
----
-
-## When Konditional Fits
-
-**Choose Konditional when:**
-
-- You want compile-time correctness for flag definitions and callsites
-- You need typed values beyond on/off booleans (variants, thresholds, configuration)
-- You value consistency over bespoke per-domain solutions
-- You run experiments and need deterministic, reproducible ramp-ups
-- You have remote configuration and want explicit validation boundaries
-
-**Konditional might not fit if:**
-
-- You need vendor-hosted dashboards more than compile-time safety
-- Your flags are fully dynamic with zero static definitions
-- You're okay with process and tooling to prevent string key drift
-
----
-
-## Real Problems Konditional Prevents
-
-### Production incident: Type coercion
-
-A string-keyed SDK returns `0` when parsing `"max_retries": "disabled"`. Service retries 0 times. All requests fail
-immediately.
-
-**With Konditional:** Parse fails at boundary. `ParseResult.Failure` logged. Last-known-good remains active. No
-incident.
-
-### Experiment contamination: Inconsistent bucketing
-
-Two teams implement ramp-ups with different hashing. Same user gets opposite buckets. A/B test results polluted.
-
-**With Konditional:** All ramp-ups use deterministic SHA-256 bucketing. Same user, same bucket. Clean results.
-
-### Maintenance burden: Boolean explosion
-
-Feature has 5 boolean flags for variants. Testing requires 32 combinations. Most undefined. Bugs hide in interactions.
-
-**With Konditional:** One flag, typed value, explicit variants. Testing covers defined cases. Code readable.
-
----
-
-## Migration Path
-
-Coming from a boolean capability system:
-
-1. **Mirror existing flags** as properties:
-   ```kotlin
-   object Features : Namespace("app") {
-       val featureX by boolean<Context>(default = false)
-   }
-   ```
-
-2. **Centralize evaluation** into rules:
-   ```kotlin
-   val featureX by boolean<Context>(default = false) {
-       rule(true) { android() }
-       rule(true) { rampUp { 25.0 } }
-   }
-   ```
-
-3. **Replace boolean matrices** with typed values:
-   ```kotlin
-   // Before: CHECKOUT_V1, CHECKOUT_V2, CHECKOUT_V3 (3 booleans)
-   enum class CheckoutVersion { V1, V2, V3 }
-   val checkoutVersion by enum<CheckoutVersion, Context>(default = V1) {
-       rule(V2) { rampUp { 33.0 } }
-       rule(V3) { rampUp { 66.0 } }
-   }
-   ```
-
-4. **Add remote config** with explicit boundaries:
-   ```kotlin
-   when (val result = NamespaceSnapshotLoader(Features).load(json)) {
-       is ParseResult.Success -> Unit
-       is ParseResult.Failure -> keepLastKnownGood()
-   }
-   ```
-
-See the [Migration Guide](./guides/migration-from-legacy.md) for detailed patterns.
-
----
-
-## Summary
-
-Feature flags aren't a "nice to have." They're load-bearing infrastructure. When they fail, they fail at scale,
-in production, with user impact.
-
-Konditional exists because **stringly-typed systems cause production incidents**, **boolean-only systems create
-maintenance nightmares**, and **inconsistent evaluation semantics make experiments untrustworthy**.
-
-The solution is structural: bind types at compile-time, centralize evaluation semantics, and draw explicit boundaries
-between static definitions and dynamic configuration.
-
-## Next Steps
-
-- [Installation](./getting-started/installation) — Add Konditional to your project
-- [Your First Feature](./getting-started/your-first-flag) — Define and evaluate your first feature flag
-- [Core Concepts](./learn/core-primitives) — Understand the foundational types
-- [Claims Registry](./theory/claims-registry) — Every design claim, test evidence, and scope
-- [Verified Design Synthesis](./theory/verified-synthesis) — Cross-document, code-verified invariants and trade-offs
+- Understand architecture: [Concepts](/concepts/namespaces)
+- Execute tasks: [Guides](/guides/remote-configuration)
+- Look up exact contracts: [Reference](/reference/api-surface)
+- Review guarantees: [Theory](/theory/type-safety-boundaries)

--- a/konditional-core/src/main/kotlin/io/amichne/konditional/context/Context.kt
+++ b/konditional-core/src/main/kotlin/io/amichne/konditional/context/Context.kt
@@ -1,8 +1,14 @@
 package io.amichne.konditional.context
 
+import io.amichne.konditional.api.KonditionalInternalApi
+import io.amichne.konditional.api.evaluateInternal
 import io.amichne.konditional.context.axis.AxisValue
 import io.amichne.konditional.context.axis.AxisValues
+import io.amichne.konditional.core.Namespace
+import io.amichne.konditional.core.features.Feature
 import io.amichne.konditional.core.id.StableId
+import io.amichne.konditional.core.ops.Metrics
+import io.amichne.konditional.core.registry.NamespaceRegistry
 
 /**
  * Represents the execution context for feature flag evaluation.
@@ -115,4 +121,11 @@ interface Context {
         internal fun Context.getAxisValue(axisId: String): Set<AxisValue<*>> =
             axisValues[axisId]
     }
+
+
+    @Suppress("UNCHECKED_CAST")
+    @OptIn(KonditionalInternalApi::class)
+    fun <T : Any, C : Context, M : Namespace> Feature<T, C, M>.evaluate(
+        registry: NamespaceRegistry = namespace,
+    ): T = evaluateInternal(this@Context as C, registry, mode = Metrics.Evaluation.EvaluationMode.NORMAL).value
 }

--- a/konditional-core/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt
+++ b/konditional-core/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt
@@ -1,6 +1,28 @@
 package io.amichne.konditional.core.types
 
+import io.amichne.kontracts.dsl.booleanSchema
+import io.amichne.kontracts.dsl.doubleSchema
+import io.amichne.kontracts.dsl.intSchema
+import io.amichne.kontracts.dsl.stringSchema
+import io.amichne.kontracts.schema.BooleanSchema
+import io.amichne.kontracts.schema.DoubleSchema
+import io.amichne.kontracts.schema.IntSchema
 import io.amichne.kontracts.schema.JsonSchema
+import io.amichne.kontracts.schema.StringSchema
+
+// Default schema singletons used by the As* interface family.
+// Each is a plain schema with no constraints — implementors override to add them.
+@Suppress("UNCHECKED_CAST")
+private val defaultStringSchema: StringSchema = stringSchema() as StringSchema
+
+@Suppress("UNCHECKED_CAST")
+private val defaultIntSchema: IntSchema = intSchema() as IntSchema
+
+@Suppress("UNCHECKED_CAST")
+private val defaultBooleanSchema: BooleanSchema = booleanSchema() as BooleanSchema
+
+@Suppress("UNCHECKED_CAST")
+private val defaultDoubleSchema: DoubleSchema = doubleSchema() as DoubleSchema
 
 /**
  * Interface for custom types that can be encoded with schema validation.
@@ -51,11 +73,42 @@ import io.amichne.kontracts.schema.JsonSchema
  * }
  * ```
  *
+ * ### Custom-type adapters (As* family — for non-primitive domain types)
+ * When the domain value type `T` is not itself a JSON primitive (e.g., `LocalDate`, `UUID`,
+ * a newtype wrapper, etc.), use the [AsString], [AsInt], [AsBoolean], or [AsDouble]
+ * sub-interfaces to declare the JSON wire format and supply encode/decode logic.
+ *
+ * Both [AsString.encode] (instance → wire) and [AsString.decode] (wire → instance) are
+ * declared directly on the interface, making the full codec contract visible. Shared logic
+ * can be extracted into standalone [Encoder] and [Decoder] objects and reused across types:
+ *
+ * ```kotlin
+ * private val localDateDecoder = Konstrained.Decoder<String, LocalDate> { LocalDate.parse(it) }
+ *
+ * @JvmInline
+ * value class ExpirationDate(val value: LocalDate) : Konstrained.AsString<LocalDate, ExpirationDate> {
+ *     override fun encode(): String = value.toString()
+ *     override fun decode(raw: String): ExpirationDate = ExpirationDate(localDateDecoder.decode(raw))
+ *
+ *     companion object : Konstrained.Decoder<String, ExpirationDate> {
+ *         override fun decode(raw: String) = ExpirationDate(localDateDecoder.decode(raw))
+ *     }
+ * }
+ * ```
+ *
+ * The companion object implementing [Decoder] allows the serialization codec to reconstruct
+ * instances from snapshots (where no prototype is available). Schema declaration is optional;
+ * the default is an unconstrained schema. Override [AsString.schema] to add constraints.
+ *
  * ## Invariants
  * - For primitive and array schemas the implementing class **must** have exactly one property
  *   whose type matches the schema's Kotlin backing type. Violations produce a descriptive
  *   [IllegalArgumentException] at encode/decode time.
- * - Determinism: [schema] must return the same value for every call on the same instance.
+ * - For [AsString] / [AsInt] / [AsBoolean] / [AsDouble] types whose companion implements
+ *   [Decoder], [Decoder.decode] must be the left-inverse of [AsString.encode]:
+ *   `decode(encode(x)).value == x`.
+ * - Determinism: [schema] must return a value-equal result on every call. Creating a new schema
+ *   instance per call is acceptable as long as its properties are identical each time.
  * - Boundary discipline: raw external values (JSON, HTTP) are never accepted as trusted;
  *   all construction goes through the schema-validated codec.
  *
@@ -72,6 +125,9 @@ sealed interface Konstrained<out S : JsonSchema<*>> {
      */
     val schema: S
 
+    // -------------------------------------------------------------------------
+    // Primitive family — value IS a JSON primitive
+    // -------------------------------------------------------------------------
 
     sealed interface Primitive<S : JsonSchema<*>, V> : Konstrained<S> {
         /**
@@ -95,5 +151,193 @@ sealed interface Konstrained<out S : JsonSchema<*>> {
          * Must be the only property of the implementing class, and its type must match the schema's backing type.
          */
         val values: List<E>
+    }
+
+    // -------------------------------------------------------------------------
+    // Composable codec interfaces — standalone building blocks for the As* family
+    // -------------------------------------------------------------------------
+
+    /**
+     * Converts a domain value [T] to its JSON-primitive wire representation [P].
+     *
+     * Implement as a standalone `object` or `fun interface` lambda to share encoding
+     * logic across multiple [AsString] / [AsInt] / [AsBoolean] / [AsDouble] types that
+     * wrap the same domain type:
+     *
+     * ```kotlin
+     * val localDateEncoder = Konstrained.Encoder<LocalDate, String> { it.toString() }
+     * ```
+     *
+     * ### Invariants
+     * - [encode] must be pure and deterministic: same [T] → same [P] always.
+     *
+     * @param T The domain type being encoded.
+     * @param P The JSON-primitive target type (`String`, `Int`, `Boolean`, or `Double`).
+     */
+    fun interface Encoder<T : Any, P : Any> {
+        fun encode(value: T): P
+    }
+
+    /**
+     * Reconstructs a [V] instance from a raw JSON-primitive value [P].
+     *
+     * Implement as a standalone `object` to share decoding logic across multiple types,
+     * or supply from a **companion object** of an [AsString] / [AsInt] / [AsBoolean] /
+     * [AsDouble] implementation to enable codec discoverability:
+     *
+     * ```kotlin
+     * val localDateDecoder = Konstrained.Decoder<String, LocalDate> { LocalDate.parse(it) }
+     *
+     * companion object : Konstrained.Decoder<String, ExpirationDate> {
+     *     override fun decode(raw: String) = ExpirationDate(localDateDecoder.decode(raw))
+     * }
+     * ```
+     *
+     * The serialization codec checks whether a class's companion object implements this
+     * interface and uses it to reconstruct instances from snapshots (where no prototype
+     * instance is available). If no companion [Decoder] is present, the codec falls back
+     * to primary-constructor invocation — suitable only for [Primitive] types whose single
+     * constructor parameter is the raw primitive itself.
+     *
+     * ### Invariants
+     * - [decode] must be the left-inverse of the corresponding [Encoder.encode]:
+     *   `decoder.decode(encoder.encode(x)) == x`.
+     * - [decode] must throw a descriptive exception (not return `null`) if [raw] is invalid.
+     *
+     * @param P The raw JSON-primitive source type.
+     * @param V The [Konstrained] value type produced by [decode].
+     */
+    fun interface Decoder<P : Any, out V : Any> {
+        fun decode(raw: P): V
+    }
+
+    // -------------------------------------------------------------------------
+    // Adapted family — domain type T is encoded AS a JSON primitive
+    //
+    // Use these when T is not itself a JSON primitive (e.g. LocalDate, UUID).
+    //
+    // Both encode() and decode() are declared on the interface, making the full
+    // codec contract explicit and testable without relying on hidden conventions.
+    //
+    // Composition: delegate to shared Encoder / Decoder objects to avoid
+    // duplicating parse/format logic across types that wrap the same domain type.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Marker for a type whose domain value [T] is serialized as a JSON **string**.
+     *
+     * - [encode] (instance) converts the wrapped value to its string wire form.
+     * - [decode] (instance) reconstructs a new [V] instance from the raw wire string.
+     *   Typically delegates to the companion [Decoder] for a single source of truth.
+     * - [schema] defaults to an unconstrained [StringSchema]; override to add `format`,
+     *   `pattern`, or `minLength` constraints.
+     *
+     * ## Codec discoverability
+     *
+     * The companion object of the implementing class **should** implement
+     * [Konstrained.Decoder]`<String, V>` so the serialization codec can reconstruct
+     * instances from snapshots without a prototype:
+     *
+     * ```kotlin
+     * companion object : Konstrained.Decoder<String, ExpirationDate> {
+     *     override fun decode(raw: String) = ExpirationDate(LocalDate.parse(raw))
+     * }
+     * ```
+     *
+     * ## Composition
+     *
+     * ```kotlin
+     * private val localDateDecoder = Konstrained.Decoder<String, LocalDate> { LocalDate.parse(it) }
+     *
+     * @JvmInline
+     * value class ExpirationDate(val value: LocalDate) : Konstrained.AsString<LocalDate, ExpirationDate> {
+     *     override fun encode(): String = value.toString()
+     *     override fun decode(raw: String): ExpirationDate = ExpirationDate(localDateDecoder.decode(raw))
+     *     companion object : Konstrained.Decoder<String, ExpirationDate> {
+     *         override fun decode(raw: String) = ExpirationDate(localDateDecoder.decode(raw))
+     *     }
+     * }
+     * ```
+     *
+     * ### Invariants
+     * - [encode] must be pure and deterministic: same [T] → same [String] always.
+     * - [decode] must be the left-inverse of [encode]: `decode(encode(x)).value == x`.
+     *
+     * @param T The domain type wrapped by this value class.
+     * @param V The concrete self-type; enables type-safe [decode] return without casting.
+     */
+    interface AsString<T : Any, V : AsString<T, V>> : Konstrained<StringSchema> {
+        /** The domain value held by this instance. */
+        val value: T
+
+        /**
+         * Encodes [value] to its JSON string wire representation.
+         *
+         * Must be pure and deterministic.
+         */
+        fun encode(): kotlin.String
+
+        /**
+         * Reconstructs a new [V] instance from the raw wire string [raw].
+         *
+         * Must be the left-inverse of [encode]: `decode(encode(x)).value == x`.
+         * Must throw a descriptive exception if [raw] is invalid.
+         */
+        fun decode(raw: kotlin.String): V
+
+        /**
+         * The [StringSchema] used to validate and describe the wire representation.
+         *
+         * Defaults to an unconstrained string schema. Override to add constraints:
+         * ```kotlin
+         * override val schema = stringSchema { format = "date" } as StringSchema
+         * ```
+         */
+        override val schema: StringSchema get() = defaultStringSchema
+    }
+
+    /**
+     * Marker for a type whose domain value [T] is serialized as a JSON **integer**.
+     *
+     * See [AsString] for the full contract; this variant uses [Int] as the wire type.
+     *
+     * @param T The domain type wrapped by this value class.
+     * @param V The concrete self-type; enables type-safe [decode] return.
+     */
+    interface AsInt<T : Any, V : AsInt<T, V>> : Konstrained<IntSchema> {
+        val value: T
+        fun encode(): kotlin.Int
+        fun decode(raw: kotlin.Int): V
+        override val schema: IntSchema get() = defaultIntSchema
+    }
+
+    /**
+     * Marker for a type whose domain value [T] is serialized as a JSON **boolean**.
+     *
+     * See [AsString] for the full contract; this variant uses [Boolean] as the wire type.
+     *
+     * @param T The domain type wrapped by this value class.
+     * @param V The concrete self-type; enables type-safe [decode] return.
+     */
+    interface AsBoolean<T : Any, V : AsBoolean<T, V>> : Konstrained<BooleanSchema> {
+        val value: T
+        fun encode(): kotlin.Boolean
+        fun decode(raw: kotlin.Boolean): V
+        override val schema: BooleanSchema get() = defaultBooleanSchema
+    }
+
+    /**
+     * Marker for a type whose domain value [T] is serialized as a JSON **number (double)**.
+     *
+     * See [AsString] for the full contract; this variant uses [Double] as the wire type.
+     *
+     * @param T The domain type wrapped by this value class.
+     * @param V The concrete self-type; enables type-safe [decode] return.
+     */
+    interface AsDouble<T : Any, V : AsDouble<T, V>> : Konstrained<DoubleSchema> {
+        val value: T
+        fun encode(): kotlin.Double
+        fun decode(raw: kotlin.Double): V
+        override val schema: DoubleSchema get() = defaultDoubleSchema
     }
 }

--- a/konditional-serialization/src/main/kotlin/io/amichne/konditional/serialization/SchemaValueCodec.kt
+++ b/konditional-serialization/src/main/kotlin/io/amichne/konditional/serialization/SchemaValueCodec.kt
@@ -24,6 +24,7 @@ import io.amichne.kontracts.value.JsonString
 import io.amichne.kontracts.value.JsonValue
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
+import kotlin.reflect.full.companionObjectInstance
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
 
@@ -72,11 +73,18 @@ object SchemaValueCodec {
 
     /**
      * Encodes any [Konstrained] instance to the appropriate [JsonValue] by dispatching on
-     * its declared schema type.
+     * its runtime type and declared schema.
      *
-     * - Object schemas → [JsonObject] (via field-reflection codec)
-     * - String/Boolean/Int/Double schemas → the matching JSON primitive
-     * - Array schemas → [JsonArray] from the single list-typed property
+     * Dispatch order:
+     * 1. [Konstrained.AsString] / [Konstrained.AsInt] / [Konstrained.AsBoolean] /
+     *    [Konstrained.AsDouble] — calls the instance's [Konstrained.AsString.encode] method,
+     *    enabling domain types that are not themselves JSON primitives (e.g. `LocalDate`).
+     *    Checked first so that an `AsString<LocalDate>` (whose `schema` IS a `StringSchema`)
+     *    does not accidentally fall into the [Konstrained.Primitive.String] path.
+     * 2. Object schemas → [JsonObject] (via field-reflection codec)
+     * 3. String/Boolean/Int/Double schemas → the matching JSON primitive (existing path,
+     *    for [Konstrained.Primitive] types whose value IS the primitive).
+     * 4. Array schemas → [JsonArray] from the single list-typed property.
      *
      * @throws IllegalArgumentException if the schema type is unsupported, or if the
      *   implementing class does not have the required single-property structure for
@@ -84,27 +92,48 @@ object SchemaValueCodec {
      */
     @KonditionalInternalApi
     fun encodeKonstrained(konstrained: Konstrained<*>): JsonValue =
-        when (val schema = konstrained.schema) {
-            is ObjectTraits -> encode(konstrained, schema.asObjectSchema())
-            is StringSchema -> jsonValue { string(konstrained.extractSinglePrimitiveProperty()) }
-            is BooleanSchema -> jsonValue { boolean(konstrained.extractSinglePrimitiveProperty()) }
-            is IntSchema -> jsonValue { number(konstrained.extractSinglePrimitiveProperty<Int>()) }
-            is DoubleSchema -> jsonValue { number(konstrained.extractSinglePrimitiveProperty<Double>()) }
-            is ArraySchema<*> -> encodeKonstrainedArray(konstrained)
+        when {
+            // Adapted family: domain type T → JSON primitive via the instance's encode().
+            konstrained is Konstrained.AsString<*, *> -> jsonValue { string(konstrained.encode()) }
+            konstrained is Konstrained.AsInt<*, *> -> jsonValue { number(konstrained.encode()) }
+            konstrained is Konstrained.AsBoolean<*, *> -> jsonValue { boolean(konstrained.encode()) }
+            konstrained is Konstrained.AsDouble<*, *> -> jsonValue { number(konstrained.encode()) }
             else ->
-                error(
-                    "Unsupported schema type for Konstrained encoding: ${schema::class.simpleName}. " +
-                        "Supported: ObjectSchema, RootObjectSchema, StringSchema, BooleanSchema, " +
-                        "IntSchema, DoubleSchema, ArraySchema.",
-                )
+                when (val schema = konstrained.schema) {
+                    is ObjectTraits -> encode(konstrained, schema.asObjectSchema())
+                    is StringSchema -> jsonValue { string(konstrained.extractSinglePrimitiveProperty()) }
+                    is BooleanSchema -> jsonValue { boolean(konstrained.extractSinglePrimitiveProperty()) }
+                    is IntSchema -> jsonValue { number(konstrained.extractSinglePrimitiveProperty<Int>()) }
+                    is DoubleSchema -> jsonValue { number(konstrained.extractSinglePrimitiveProperty<Double>()) }
+                    is ArraySchema<*> -> encodeKonstrainedArray(konstrained)
+                    else ->
+                        error(
+                            "Unsupported schema type for Konstrained encoding: ${schema::class.simpleName}. " +
+                                "Supported: ObjectSchema, RootObjectSchema, StringSchema, BooleanSchema, " +
+                                "IntSchema, DoubleSchema, ArraySchema. " +
+                                "For non-primitive domain types implement Konstrained.AsString / AsInt / " +
+                                "AsBoolean / AsDouble and supply a companion Konstrained.Decoder.",
+                        )
+                }
         }
 
     /**
      * Decodes a raw primitive or list value back into a [Konstrained] value class instance.
      *
-     * The [kClass] must have a primary constructor with exactly one parameter whose type is
-     * assignment-compatible with [rawValue]. `@JvmInline value class` satisfies this by
-     * construction.
+     * ## Dispatch order
+     *
+     * 1. **Companion [Konstrained.Decoder]** — if the target class has a companion object
+     *    that implements [Konstrained.Decoder]`<P, T>` (where `P` matches the runtime type
+     *    of [rawValue]), the companion's [Konstrained.Decoder.decode] is called directly.
+     *    This is the canonical path for [Konstrained.AsString] / [Konstrained.AsInt] /
+     *    [Konstrained.AsBoolean] / [Konstrained.AsDouble] types whose wrapped domain value
+     *    is not itself a JSON primitive (e.g. `LocalDate`, `UUID`).
+     *
+     * 2. **Primary constructor** — fallback for [Konstrained.Primitive] types whose single
+     *    constructor parameter type matches [rawValue] directly (e.g. `Email(value: String)`).
+     *    The [kClass] must have a primary constructor with exactly one parameter whose type
+     *    is assignment-compatible with [rawValue]. `@JvmInline value class` satisfies this by
+     *    construction.
      *
      * @param kClass Target class to instantiate (typically a value class).
      * @param rawValue The raw primitive (`String`, `Boolean`, `Int`, `Double`) or `List<*>`.
@@ -114,6 +143,13 @@ object SchemaValueCodec {
     @KonditionalInternalApi
     @Suppress("ReturnCount")
     fun <T : Any> decodeKonstrainedPrimitive(kClass: KClass<T>, rawValue: Any): Result<T> {
+        // Step 1: prefer a companion Decoder when present — supports As* types with
+        // non-primitive domain values. The cast is safe: the companion is the companion
+        // of kClass (which produces T), and Decoder's V parameter is covariant.
+        val decoderResult = decodeViaDecoder(kClass, rawValue)
+        if (decoderResult != null) return decoderResult
+
+        // Step 2: fall back to direct constructor invocation for Konstrained.Primitive types.
         val constructor =
             kClass.primaryConstructor
                 ?: return parseFailure(
@@ -143,6 +179,61 @@ object SchemaValueCodec {
                     )
                 },
             )
+    }
+
+    /**
+     * Attempts to decode [rawValue] via a companion-object [Konstrained.Decoder], returning
+     * `null` when no matching companion decoder is found so the caller can fall through to
+     * the primary-constructor path.
+     *
+     * A single [Konstrained.Decoder]`<P, V>` interface replaces the previous four bespoke
+     * `StringDecoder` / `IntDecoder` / `BooleanDecoder` / `DoubleDecoder` interfaces.
+     * The `P` type parameter is inferred from the runtime type of [rawValue]; the unchecked
+     * cast to `Decoder<P, T>` is safe because the companion is the companion of [kClass],
+     * which by the [Konstrained.Decoder] contract produces values of type `T`.
+     */
+    @Suppress("UNCHECKED_CAST", "ReturnCount")
+
+    private fun <T : Any> decodeViaDecoder(
+        kClass: KClass<T>,
+        rawValue: Any
+    ): Result<T>? {
+        val companion = kClass.companionObjectInstance ?: return null
+        if (companion !is Konstrained.Decoder<*, *>) return null
+        val errorMessage: (Throwable) -> String = {
+            "Decoder on ${kClass.qualifiedName} failed for value '$rawValue': ${it.message}"
+        }
+        return when (rawValue) {
+            is String ->
+                runCatching { (companion as Konstrained.Decoder<String, T>).decode(rawValue) }
+                    .fold(
+                        onSuccess = { Result.success(it) },
+                        onFailure = { parseFailure(ParseError.InvalidSnapshot(errorMessage(it))) },
+                    )
+
+            is Int ->
+                runCatching { (companion as Konstrained.Decoder<Int, T>).decode(rawValue) }
+                    .fold(
+                        onSuccess = { Result.success(it) },
+                        onFailure = { parseFailure(ParseError.InvalidSnapshot(errorMessage(it))) },
+                    )
+
+            is Boolean ->
+                runCatching { (companion as Konstrained.Decoder<Boolean, T>).decode(rawValue) }
+                    .fold(
+                        onSuccess = { Result.success(it) },
+                        onFailure = { parseFailure(ParseError.InvalidSnapshot(errorMessage(it))) },
+                    )
+
+            is Double ->
+                runCatching { (companion as Konstrained.Decoder<Double, T>).decode(rawValue) }
+                    .fold(
+                        onSuccess = { Result.success(it) },
+                        onFailure = { parseFailure(ParseError.InvalidSnapshot(errorMessage(it))) },
+                    )
+
+            else -> null
+        }
     }
 
     private fun encodeValue(value: Any): JsonValue =
@@ -367,7 +458,7 @@ private inline fun <reified T : Any> Konstrained<*>.extractSinglePrimitiveProper
     val matching = allProps.filter { it.returnType.classifier == T::class }
     val prop =
         when {
-            primaryConstructorProp != null && primaryConstructorProp.returnType.classifier == T::class -> primaryConstructorProp
+            primaryConstructorProp?.returnType?.classifier == T::class -> primaryConstructorProp
             matching.size == 1 -> matching[0]
             matching.isEmpty() && allProps.size == 1 -> allProps[0]
             matching.isEmpty() ->

--- a/konditional-serialization/src/test/kotlin/io/amichne/konditional/fixtures/serializers/PrimitiveKonstrainedFixtures.kt
+++ b/konditional-serialization/src/test/kotlin/io/amichne/konditional/fixtures/serializers/PrimitiveKonstrainedFixtures.kt
@@ -11,7 +11,14 @@ import io.amichne.kontracts.schema.ArraySchema
 import io.amichne.kontracts.schema.BooleanSchema
 import io.amichne.kontracts.schema.DoubleSchema
 import io.amichne.kontracts.schema.IntSchema
+import io.amichne.kontracts.schema.JsonSchema
 import io.amichne.kontracts.schema.StringSchema
+import java.time.LocalDate
+import java.util.UUID
+
+// ---------------------------------------------------------------------------
+// Primitive family — value IS the JSON primitive
+// ---------------------------------------------------------------------------
 
 /** Value-class-backed string Konstrained with a pattern constraint. */
 @JvmInline
@@ -30,7 +37,7 @@ value class RetryCount(override val value: Int) : Konstrained.Primitive.Int<IntS
 /** Value-class-backed boolean Konstrained. */
 @JvmInline
 value class FeatureEnabled(val enabled: Boolean) : Konstrained.Primitive.Boolean<BooleanSchema> {
-    override val value: kotlin.Boolean get() = enabled
+    override val value: Boolean get() = enabled
     override val schema: BooleanSchema
         get() = booleanSchema { default = false } as BooleanSchema
 }
@@ -46,5 +53,76 @@ value class Percentage(override val value: Double) : Konstrained.Primitive.Doubl
 @JvmInline
 value class Tags(override val values: List<String>) : Konstrained.Array<ArraySchema<String>, String> {
     override val schema: ArraySchema<String>
-        get() = arraySchema { elementSchema(stringSchema { minLength = 1 }) } as ArraySchema<String>
+        get() = arraySchema { elementSchema(stringSchema { minLength = 1 }) }
+}
+
+// ---------------------------------------------------------------------------
+// As* family — domain type T encoded AS a JSON primitive
+// ---------------------------------------------------------------------------
+
+// Shared Decoder instances — reused across multiple types that wrap the same domain type,
+// eliminating duplicate parse/format logic. These are the Konstrained.Decoder analogue
+// of a Moshi TypeAdapter that can be applied to many fields.
+private val localDateDecoder: Konstrained.Decoder<String, LocalDate> =
+    Konstrained.Decoder { LocalDate.parse(it) }
+
+private val uuidDecoder: Konstrained.Decoder<String, UUID> =
+    Konstrained.Decoder { UUID.fromString(it) }
+
+/**
+ * A calendar date serialized as an ISO-8601 string (e.g. `"2025-06-15"`).
+ *
+ * Demonstrates [Konstrained.AsString] with a non-primitive domain type ([LocalDate]).
+ * No explicit schema override — the default unconstrained [StringSchema] is used.
+ *
+ * Both [encode] and [decode] are declared on the [Konstrained.AsString] interface,
+ * making the full codec contract visible without any hidden companion conventions.
+ * The companion implements [Konstrained.Decoder] so the serialization codec can
+ * reconstruct instances from snapshots (where no prototype instance is available).
+ * The instance [decode] delegates to the companion to keep logic in one place.
+ */
+@JvmInline
+value class ExpirationDate(override val value: LocalDate) : Konstrained.AsString<LocalDate, ExpirationDate> {
+    override fun encode(): String = value.toString()
+    override fun decode(raw: String): ExpirationDate = Companion.decode(raw)
+
+    companion object : Konstrained.Decoder<String, ExpirationDate> {
+        override fun decode(raw: String): ExpirationDate = ExpirationDate(localDateDecoder.decode(raw))
+    }
+}
+
+/**
+ * A calendar date with an explicit schema override declaring the `"date"` OpenAPI format.
+ *
+ * Demonstrates optional schema customization on top of [Konstrained.AsString].
+ * Reuses [localDateDecoder] — the same [Konstrained.Decoder] shared with [ExpirationDate].
+ */
+@JvmInline
+value class AuditDate(override val value: LocalDate) : Konstrained.AsString<LocalDate, AuditDate> {
+    @Suppress("UNCHECKED_CAST")
+    override val schema: StringSchema
+        get() = stringSchema { format = "date" } as StringSchema
+
+    override fun encode(): String = value.toString()
+    override fun decode(raw: String): AuditDate = Companion.decode(raw)
+
+    companion object : Konstrained.Decoder<String, AuditDate> {
+        override fun decode(raw: String): AuditDate = AuditDate(localDateDecoder.decode(raw))
+    }
+}
+
+/**
+ * A [UUID] correlation identifier serialized as its canonical hyphenated string form.
+ *
+ * Demonstrates [Konstrained.AsString] with a second non-primitive domain type,
+ * reusing [uuidDecoder] for the parse step.
+ */
+@JvmInline
+value class CorrelationId(override val value: UUID) : Konstrained.AsString<UUID, CorrelationId> {
+    override fun encode(): String = value.toString()
+    override fun decode(raw: String): CorrelationId = Companion.decode(raw)
+
+    companion object : Konstrained.Decoder<String, CorrelationId> {
+        override fun decode(raw: String): CorrelationId = CorrelationId(uuidDecoder.decode(raw))
+    }
 }

--- a/konditional-serialization/src/test/kotlin/io/amichne/konditional/serialization/ConfigurationSnapshotCodecTest.kt
+++ b/konditional-serialization/src/test/kotlin/io/amichne/konditional/serialization/ConfigurationSnapshotCodecTest.kt
@@ -168,7 +168,7 @@ class ConfigurationSnapshotCodecTest {
 
         assertIs<ParseResult.Failure>(result)
         assertIs<ParseError.InvalidSnapshot>(result.error)
-        assertTrue((result.error as ParseError.InvalidSnapshot).reason.contains("compile-time schema"))
+        assertTrue(result.error.reason.contains("compile-time schema"))
     }
 
     @Test
@@ -184,7 +184,7 @@ class ConfigurationSnapshotCodecTest {
 
         assertIs<ParseResult.Failure>(result)
         assertIs<ParseError.InvalidSnapshot>(result.error)
-        assertTrue((result.error as ParseError.InvalidSnapshot).reason.contains("compile-time schema"))
+        assertTrue(result.error.reason.contains("compile-time schema"))
     }
 
     @Test
@@ -801,7 +801,7 @@ class ConfigurationSnapshotCodecTest {
 
         assertIs<ParseResult.Failure>(result)
         assertIs<ParseError.FeatureNotFound>(result.error)
-        val error = result.error as ParseError.FeatureNotFound
+        val error = result.error
         assertEquals(FeatureId.create("global", "unregistered_feature"), error.key)
     }
 

--- a/konditional-serialization/src/test/kotlin/io/amichne/konditional/serialization/FeatureRegistryTest.kt
+++ b/konditional-serialization/src/test/kotlin/io/amichne/konditional/serialization/FeatureRegistryTest.kt
@@ -4,7 +4,6 @@ package io.amichne.konditional.serialization
 
 import io.amichne.konditional.context.Context
 import io.amichne.konditional.core.Namespace
-import io.amichne.konditional.core.features.Feature
 import io.amichne.konditional.core.result.ParseError
 import io.amichne.konditional.core.result.parseErrorOrNull
 import io.amichne.konditional.values.FeatureId
@@ -83,10 +82,7 @@ class FeatureRegistryTest {
         assertTrue(result.isFailure)
         val error = result.parseErrorOrNull()
         assertTrue(error is ParseError.FeatureNotFound)
-        assertEquals(
-            FeatureId.create("test", "nonexistent_key"),
-            (error as ParseError.FeatureNotFound).key
-        )
+        assertEquals(FeatureId.create("test", "nonexistent_key"), error.key)
     }
 
     @Test

--- a/konditional-serialization/src/test/kotlin/io/amichne/konditional/serialization/KonstrainedCustomTypeTest.kt
+++ b/konditional-serialization/src/test/kotlin/io/amichne/konditional/serialization/KonstrainedCustomTypeTest.kt
@@ -1,0 +1,307 @@
+@file:OptIn(KonditionalInternalApi::class)
+
+package io.amichne.konditional.serialization
+
+import com.squareup.moshi.Moshi
+import io.amichne.konditional.api.KonditionalInternalApi
+import io.amichne.konditional.api.evaluate
+import io.amichne.konditional.context.AppLocale
+import io.amichne.konditional.context.Context
+import io.amichne.konditional.context.Platform
+import io.amichne.konditional.context.Version
+import io.amichne.konditional.core.Namespace
+import io.amichne.konditional.fixtures.core.id.TestStableId
+import io.amichne.konditional.fixtures.core.withOverride
+import io.amichne.konditional.fixtures.serializers.AuditDate
+import io.amichne.konditional.fixtures.serializers.CorrelationId
+import io.amichne.konditional.fixtures.serializers.ExpirationDate
+import io.amichne.konditional.internal.serialization.adapters.FlagValueAdapterFactory
+import io.amichne.konditional.internal.serialization.models.FlagValue
+import io.amichne.konditional.serialization.instance.ConfigValue
+import io.amichne.konditional.serialization.snapshot.ConfigurationSnapshotCodec
+import io.amichne.kontracts.value.JsonString
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Tests for [io.amichne.konditional.core.types.Konstrained.AsString] (and family) support.
+ *
+ * Validates:
+ * - [SchemaValueCodec.encodeKonstrained] uses the instance [encode] method
+ * - [SchemaValueCodec.decodeKonstrainedPrimitive] uses the companion [Konstrained.Decoder]
+ * - The instance [decode] method is the inverse of [encode] (round-trip via interface)
+ * - [FlagValue.from] / [FlagValue.extractValue] round-trip correctness
+ * - Moshi serialization / deserialization of [FlagValue.KonstrainedPrimitive]
+ * - [ConfigValue.from] dispatches correctly for As* types
+ * - Feature flag integration with custom-type Konstrained
+ * - Schema default vs explicit override behaviour
+ */
+class KonstrainedCustomTypeTest {
+
+    private val moshi = Moshi.Builder()
+        .add(FlagValueAdapterFactory)
+        .build()
+
+    private val adapter = moshi.adapter(FlagValue::class.java)
+
+    private val context = Context(
+        locale = AppLocale.UNITED_STATES,
+        platform = Platform.ANDROID,
+        appVersion = Version(1, 0, 0),
+        stableId = TestStableId,
+    )
+
+    // =========================================================================
+    // SchemaValueCodec.encodeKonstrained — As* dispatch
+    // =========================================================================
+
+    @Test
+    fun `encodeKonstrained produces JsonString for AsString-backed LocalDate`() {
+        val date = ExpirationDate(LocalDate.of(2025, 6, 15))
+        val encoded = SchemaValueCodec.encodeKonstrained(date)
+        assertInstanceOf(JsonString::class.java, encoded)
+        assertEquals("2025-06-15", (encoded as JsonString).value)
+    }
+
+    @Test
+    fun `encodeKonstrained produces JsonString for AsString-backed UUID`() {
+        val id = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+        val correlationId = CorrelationId(id)
+        val encoded = SchemaValueCodec.encodeKonstrained(correlationId)
+        assertInstanceOf(JsonString::class.java, encoded)
+        assertEquals("550e8400-e29b-41d4-a716-446655440000", (encoded as JsonString).value)
+    }
+
+    @Test
+    fun `encodeKonstrained uses encode() method not property extraction for AsString`() {
+        // ExpirationDate.value is LocalDate, NOT String.
+        // If the codec incorrectly tried extractSinglePrimitiveProperty<String>() it would
+        // throw. Reaching this assertion proves the encode() dispatch path was taken.
+        val date = ExpirationDate(LocalDate.of(2024, 1, 1))
+        val encoded = SchemaValueCodec.encodeKonstrained(date)
+        assertInstanceOf(JsonString::class.java, encoded)
+    }
+
+    // =========================================================================
+    // SchemaValueCodec.decodeKonstrainedPrimitive — companion Konstrained.Decoder
+    // =========================================================================
+
+    @Test
+    fun `decodeKonstrainedPrimitive uses companion Decoder for ExpirationDate`() {
+        val result = SchemaValueCodec.decodeKonstrainedPrimitive(ExpirationDate::class, "2025-06-15")
+        assertTrue(result.isSuccess)
+        assertEquals(ExpirationDate(LocalDate.of(2025, 6, 15)), result.getOrThrow())
+    }
+
+    @Test
+    fun `decodeKonstrainedPrimitive uses companion Decoder for AuditDate`() {
+        val result = SchemaValueCodec.decodeKonstrainedPrimitive(AuditDate::class, "2023-11-30")
+        assertTrue(result.isSuccess)
+        assertEquals(AuditDate(LocalDate.of(2023, 11, 30)), result.getOrThrow())
+    }
+
+    @Test
+    fun `decodeKonstrainedPrimitive uses companion Decoder for CorrelationId`() {
+        val raw = "550e8400-e29b-41d4-a716-446655440000"
+        val result = SchemaValueCodec.decodeKonstrainedPrimitive(CorrelationId::class, raw)
+        assertTrue(result.isSuccess)
+        assertEquals(CorrelationId(UUID.fromString(raw)), result.getOrThrow())
+    }
+
+    @Test
+    fun `decodeKonstrainedPrimitive returns failure when Decoder throws`() {
+        val result = SchemaValueCodec.decodeKonstrainedPrimitive(ExpirationDate::class, "not-a-date")
+        assertTrue(result.isFailure)
+    }
+
+    // =========================================================================
+    // Instance decode() — declared on AsString interface, inverse of encode()
+    // =========================================================================
+
+    @Test
+    fun `instance decode is the inverse of encode for ExpirationDate`() {
+        val original = ExpirationDate(LocalDate.of(2025, 6, 15))
+        val roundTripped = original.decode(original.encode())
+        assertEquals(original, roundTripped)
+    }
+
+    @Test
+    fun `instance decode is the inverse of encode for AuditDate`() {
+        val original = AuditDate(LocalDate.of(2023, 11, 30))
+        val roundTripped = original.decode(original.encode())
+        assertEquals(original, roundTripped)
+    }
+
+    @Test
+    fun `instance decode is the inverse of encode for CorrelationId`() {
+        val original = CorrelationId(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"))
+        val roundTripped = original.decode(original.encode())
+        assertEquals(original, roundTripped)
+    }
+
+    @Test
+    fun `ExpirationDate and AuditDate share the same underlying localDateDecoder logic`() {
+        // Both types wrap LocalDate and parse via the same shared Decoder — verify they
+        // produce structurally equal domain values from the same wire string.
+        val raw = "2025-06-15"
+        val expiry = ExpirationDate(LocalDate.of(2025, 6, 15))
+        val audit = AuditDate(LocalDate.of(2025, 6, 15))
+        assertEquals(expiry.value, audit.decode(raw).value)
+        assertEquals(expiry.decode(raw).value, audit.value)
+    }
+
+    // =========================================================================
+    // FlagValue round-trip
+    // =========================================================================
+
+    @Test
+    fun `FlagValue from ExpirationDate produces KonstrainedPrimitive with string value`() {
+        val date = ExpirationDate(LocalDate.of(2025, 3, 1))
+        val fv = FlagValue.from(date)
+        assertInstanceOf(FlagValue.KonstrainedPrimitive::class.java, fv)
+        fv as FlagValue.KonstrainedPrimitive
+        assertEquals("2025-03-01", fv.value)
+        assertEquals(ExpirationDate::class.java.name, fv.konstrainedClassName)
+    }
+
+    @Test
+    fun `FlagValue extractValue round-trips ExpirationDate`() {
+        val original = ExpirationDate(LocalDate.of(2026, 12, 31))
+        val fv = FlagValue.from(original) as FlagValue.KonstrainedPrimitive
+        assertEquals(original, fv.extractValue<ExpirationDate>())
+    }
+
+    @Test
+    fun `FlagValue extractValue round-trips CorrelationId`() {
+        val original = CorrelationId(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"))
+        val fv = FlagValue.from(original) as FlagValue.KonstrainedPrimitive
+        assertEquals(original, fv.extractValue<CorrelationId>())
+    }
+
+    @Test
+    fun `FlagValue extractValue round-trips AuditDate with schema override`() {
+        val original = AuditDate(LocalDate.of(2024, 7, 4))
+        val fv = FlagValue.from(original) as FlagValue.KonstrainedPrimitive
+        assertEquals(original, fv.extractValue<AuditDate>())
+    }
+
+    // =========================================================================
+    // Moshi serialization round-trip
+    // =========================================================================
+
+    @Test
+    fun `KonstrainedPrimitive Moshi round-trip for ExpirationDate`() {
+        val original = FlagValue.KonstrainedPrimitive(
+            value = "2025-06-15",
+            konstrainedClassName = ExpirationDate::class.java.name,
+        )
+        val json = adapter.toJson(original)
+        val deserialized = adapter.fromJson(json) as FlagValue.KonstrainedPrimitive
+        assertEquals("2025-06-15", deserialized.value)
+        assertEquals(ExpirationDate::class.java.name, deserialized.konstrainedClassName)
+    }
+
+    @Test
+    fun `KonstrainedPrimitive full end-to-end Moshi round-trip reconstructs ExpirationDate`() {
+        val original = ExpirationDate(LocalDate.of(2025, 6, 15))
+        val fv = FlagValue.from(original) as FlagValue.KonstrainedPrimitive
+        val json = adapter.toJson(fv)
+        val deserialized = adapter.fromJson(json) as FlagValue.KonstrainedPrimitive
+        assertEquals(original, deserialized.extractValue<ExpirationDate>())
+    }
+
+    // =========================================================================
+    // Schema behaviour
+    // =========================================================================
+
+    @Test
+    fun `ExpirationDate uses default StringSchema when no override provided`() {
+        val date = ExpirationDate(LocalDate.of(2025, 1, 1))
+        val schema = date.schema
+        // Default schema has no constraints
+        assertEquals(null, schema.format)
+        assertEquals(null, schema.pattern)
+    }
+
+    @Test
+    fun `AuditDate uses overridden StringSchema with format date`() {
+        val date = AuditDate(LocalDate.of(2025, 1, 1))
+        val schema = date.schema
+        assertEquals("date", schema.format)
+    }
+
+    // =========================================================================
+    // ConfigValue dispatch
+    // =========================================================================
+
+    @Test
+    fun `ConfigValue from ExpirationDate produces KonstrainedPrimitive`() {
+        val cv = ConfigValue.from(ExpirationDate(LocalDate.of(2025, 1, 1)))
+        assertInstanceOf(ConfigValue.KonstrainedPrimitive::class.java, cv)
+        cv as ConfigValue.KonstrainedPrimitive
+        assertEquals("2025-01-01", cv.rawValue)
+        assertEquals(ExpirationDate::class.java.name, cv.konstrainedClassName)
+    }
+
+    // =========================================================================
+    // Feature flag integration
+    // =========================================================================
+
+    @Test
+    fun `feature flag with ExpirationDate evaluates default and override correctly`() {
+        val defaultDate = ExpirationDate(LocalDate.of(2025, 1, 1))
+        val overrideDate = ExpirationDate(LocalDate.of(2026, 6, 30))
+
+        val features = object : Namespace.TestNamespaceFacade("expiry-flag") {
+            val expiry by custom<ExpirationDate, Context>(default = defaultDate) {}
+        }
+
+        assertEquals(defaultDate, features.expiry.evaluate(context))
+
+        features.withOverride(features.expiry, overrideDate) {
+            assertEquals(overrideDate, features.expiry.evaluate(context))
+        }
+    }
+
+    @Test
+    fun `feature flag with CorrelationId evaluates default and override correctly`() {
+        val defaultId = CorrelationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+        val overrideId = CorrelationId(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"))
+
+        val features = object : Namespace.TestNamespaceFacade("correlation-flag") {
+            val correlationId by custom<CorrelationId, Context>(default = defaultId) {}
+        }
+
+        assertEquals(defaultId, features.correlationId.evaluate(context))
+
+        features.withOverride(features.correlationId, overrideId) {
+            assertEquals(overrideId, features.correlationId.evaluate(context))
+        }
+    }
+
+    @Test
+    fun `feature flag with ExpirationDate serializes and deserializes via snapshot codec`() {
+        val defaultDate = ExpirationDate(LocalDate.of(2025, 1, 1))
+        val overrideDate = ExpirationDate(LocalDate.of(2026, 6, 30))
+
+        val features = object : Namespace.TestNamespaceFacade("snapshot-expiry-flag") {
+            val expiry by custom<ExpirationDate, Context>(default = defaultDate) {}
+        }
+
+        features.withOverride(features.expiry, overrideDate) {
+            val json = ConfigurationSnapshotCodec.encode(features.configuration)
+            val decoded = ConfigurationSnapshotCodec.decode(
+                json = json,
+                schema = features.compiledSchema(),
+            )
+            assertTrue(
+                decoded.isSuccess,
+                "Snapshot decode should succeed: ${decoded.exceptionOrNull()?.message}",
+            )
+        }
+    }
+}

--- a/kontracts/src/main/kotlin/io/amichne/kontracts/dsl/ArraySchemaBuilder.kt
+++ b/kontracts/src/main/kotlin/io/amichne/kontracts/dsl/ArraySchemaBuilder.kt
@@ -4,22 +4,22 @@ import io.amichne.kontracts.schema.ArraySchema
 import io.amichne.kontracts.schema.JsonSchema
 
 @JsonSchemaBuilderDsl
-class ArraySchemaBuilder @PublishedApi internal constructor() : JsonSchemaBuilder<List<Any>> {
+class ArraySchemaBuilder<E : Any> @PublishedApi internal constructor() : JsonSchemaBuilder<List<E>> {
     var title: String? = null
     var description: String? = null
-    var default: List<Any>? = null
+    var default: List<E>? = null
     var nullable: Boolean = false
-    var example: List<Any>? = null
+    var example: List<E>? = null
     var deprecated: Boolean = false
     var minItems: Int? = null
     var maxItems: Int? = null
     var uniqueItems: Boolean = false
-    lateinit var elementSchema: JsonSchema<Any>
-    fun element(builder: RootObjectSchemaBuilder.() -> Unit) {
-        elementSchema = RootObjectSchemaBuilder().apply(builder).build()
+    lateinit var elementSchema: JsonSchema<E>
+    fun element(builder: JsonSchemaBuilder<E>.() -> Unit) {
+        elementSchema = ArraySchemaBuilder<E>().apply { element { builder() } }.build().elementSchema
     }
 
-    override fun build() = ArraySchema(
+    override fun build(): ArraySchema<E> = ArraySchema(
         elementSchema,
         title,
         description,
@@ -33,8 +33,6 @@ class ArraySchemaBuilder @PublishedApi internal constructor() : JsonSchemaBuilde
     )
 }
 
-@JsonSchemaBuilderDsl
-@Suppress("UNCHECKED_CAST")
-fun <E : Any> ArraySchemaBuilder.elementSchema(schema: JsonSchema<E>) {
-    this.elementSchema = schema as JsonSchema<Any>
+fun <E : Any> ArraySchemaBuilder<E>.elementSchema(schema: JsonSchema<E>) {
+    this.elementSchema = schema
 }

--- a/kontracts/src/main/kotlin/io/amichne/kontracts/dsl/JsonSchemaPrimitiveDsl.kt
+++ b/kontracts/src/main/kotlin/io/amichne/kontracts/dsl/JsonSchemaPrimitiveDsl.kt
@@ -1,5 +1,6 @@
 package io.amichne.kontracts.dsl
 
+import io.amichne.kontracts.schema.ArraySchema
 import io.amichne.kontracts.schema.JsonSchema
 import kotlin.reflect.KClass
 
@@ -18,8 +19,8 @@ fun doubleSchema(builder: DoubleSchemaBuilder.() -> Unit = {}): JsonSchema<Doubl
 fun nullSchema(builder: NullSchemaBuilder.() -> Unit = {}): JsonSchema<Any> =
     NullSchemaBuilder().apply(builder).build()
 
-fun arraySchema(builder: ArraySchemaBuilder.() -> Unit): JsonSchema<List<Any>> =
-    ArraySchemaBuilder().apply(builder).build()
+inline fun <reified E : Any> arraySchema(builder: ArraySchemaBuilder<E>.() -> Unit): ArraySchema<E> =
+    ArraySchemaBuilder<E>().apply(builder).build()
 
 fun <E : Enum<E>> enumSchema(
     enumClass: KClass<E>,


### PR DESCRIPTION


Introduces four new sub-interfaces to Konstrained — AsString<T>, AsInt<T>,
AsBoolean<T>, AsDouble<T> — enabling value classes that wrap non-primitive
domain types (e.g. LocalDate, UUID) to participate in the Konstrained codec
without sacrificing type safety, parse-don't-validate, or determinism.

Design
------
- encode() is an instance method (has access to this.value).
- decode() lives on the companion object implementing the matching
  StringDecoder / IntDecoder / BooleanDecoder / DoubleDecoder interface.
  This mirrors the Moshi @ToJson / @FromJson adapter split.
- Schema defaults to an unconstrained singleton (defaultStringSchema, etc.);
  implementors override the schema property to add format/pattern constraints.

Codec changes (SchemaValueCodec)
----------------------------------
- encodeKonstrained: checks is Konstrained.AsString<*> etc. BEFORE falling
  into the schema-dispatch block, preventing an AsString<LocalDate> whose
  schema IS a StringSchema from incorrectly taking the Primitive.String path.
- decodeKonstrainedPrimitive: new decodeViaCompanionDecoder helper inspects
  the companion object instance for a matching Decoder interface and delegates
  to it; falls through to the existing primary-constructor path for Primitive
  types if no companion decoder is found.

Fixtures & tests
----------------
- ExpirationDate, AuditDate (with schema override), CorrelationId added to
  PrimitiveKonstrainedFixtures as representative As* implementations.
- KonstrainedCustomTypeTest covers: encode/decode dispatch, FlagValue
  round-trips, Moshi serialization, schema default vs override, ConfigValue
  dispatch, feature-flag integration, and snapshot-codec round-trip.