### PR TITLE
ci: manual release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,105 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: 'SemVer bump: patch, minor, or major'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
   packages: write
 
 jobs:
+  publish-manual:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
+          persist-credentials: true
+
+      - name: Force SSH origin for protected-branch push
+        run: git remote set-url origin "git@github.com:${{ github.repository }}.git"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Derive release version
+        id: version
+        run: |
+          CURRENT="$(grep -E '^version=' gradle.properties | head -n1 | cut -d'=' -f2)"
+          BASE="${CURRENT%-SNAPSHOT}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+
+          case "${{ github.event.inputs.release-type }}" in
+            major) VERSION="$((MAJOR + 1)).0.0" ;;
+            minor) VERSION="${MAJOR}.$((MINOR + 1)).0" ;;
+            patch) VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+          esac
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing version: $VERSION"
+
+          sed -i "s/^version=.*/version=$VERSION/" gradle.properties
+
+      - name: Import GPG key
+        env:
+          SIGNING_GPG_PRIVATE_KEY: ${{ secrets.SIGNING_GPG_PRIVATE_KEY }}
+          SIGNING_GPG_KEY_NAME: ${{ secrets.SIGNING_GPG_KEY_NAME }}
+        run: |
+          if ! printf '%s' "$SIGNING_GPG_PRIVATE_KEY" | gpg --batch --import; then
+            if ! printf '%s' "$SIGNING_GPG_PRIVATE_KEY" | base64 --decode | gpg --batch --import; then
+              echo "Failed to import SIGNING_GPG_PRIVATE_KEY as armored or base64-encoded key material"
+              exit 1
+            fi
+          fi
+
+      - name: Publish to Maven Central
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD }}
+          SIGNING_GPG_KEY_NAME: ${{ secrets.SIGNING_GPG_KEY_NAME }}
+          SIGNING_GPG_PASSPHRASE: ${{ secrets.SIGNING_GPG_PASSPHRASE }}
+        run: |
+          SIGNING_ARGS=(-Psigning.gnupg.keyName="$SIGNING_GPG_KEY_NAME")
+          if [ -n "${SIGNING_GPG_PASSPHRASE:-}" ]; then
+            SIGNING_ARGS+=(-Psigning.gnupg.passphrase="$SIGNING_GPG_PASSPHRASE")
+          fi
+
+          ./gradlew publishAndReleaseToMavenCentral "${SIGNING_ARGS[@]}" \
+            -Pkonditional.publish.target=release \
+            --no-configuration-cache \
+            --no-daemon \
+            --stacktrace
+
+      - name: Commit and push version bump
+        run: |
+          git add gradle.properties
+          git commit -m "chore: release ${{ steps.version.outputs.version }}"
+          git push origin ${{ github.ref_name }}
+
   validate:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -42,6 +134,7 @@ jobs:
         run: ./gradlew test --no-daemon
 
   publish-maven-central:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: validate
     outputs:
@@ -122,6 +215,7 @@ jobs:
             --stacktrace
 
   publish-github-packages:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: validate
     steps:
@@ -184,6 +278,7 @@ jobs:
     needs: [ validate, publish-maven-central, publish-github-packages ]
     if: >
       always() &&
+      github.event_name == 'push' &&
       needs.validate.result == 'success' &&
       needs.publish-github-packages.result == 'success' &&
       (needs.publish-maven-central.result == 'success' || needs.publish-maven-central.outputs.published == 'false')


### PR DESCRIPTION
Adds a patch/minor/major version selector that bumps the version from
the current gradle.properties base (stripping -SNAPSHOT), then runs
publishAndReleaseToMavenCentral with the same credentials and signing
setup as the tag-triggered path. Existing tag-push jobs are conditioned
on push events so they are unaffected.