### PR TITLE
Fix snapshot patch schema wiring and refresh observability recipes docs

### DIFF
--- a/docusaurus/docs/advanced/recipes.md
+++ b/docusaurus/docs/advanced/recipes.md
@@ -202,8 +202,8 @@ fun loadRemoteConfig() {
     val features = AppFeatures
     val result = ConfigurationSnapshotCodec.decode(json, features.compiledSchema())
 
-    result.onSuccess { materialized ->
-        features.update(materialized)
+    result.onSuccess { configuration ->
+        features.update(configuration)
     }
     result.onFailure { failure ->
         val parseErrorMessage = result.parseErrorOrNull()?.message
@@ -237,7 +237,7 @@ fun evaluateWithShadowedConfig(context: Context): Boolean {
     val candidateConfig = ConfigurationSnapshotCodec.decode(candidateJson, AppFeatures.compiledSchema()).getOrThrow()
     val candidateRegistry =
         InMemoryNamespaceRegistry(namespaceId = AppFeatures.namespaceId).apply {
-            load(candidateConfig.configuration)
+            load(candidateConfig)
         }
 
     val value =

--- a/konditional-serialization/src/main/kotlin/io/amichne/konditional/serialization/snapshot/ConfigurationSnapshotCodec.kt
+++ b/konditional-serialization/src/main/kotlin/io/amichne/konditional/serialization/snapshot/ConfigurationSnapshotCodec.kt
@@ -124,7 +124,7 @@ object ConfigurationSnapshotCodec {
                                 meta = patch.meta ?: currentSerializable.meta,
                                 flags = flagMap.values.toList(),
                             ).toConfiguration(
-                                schema = current.schema,
+                                schema = schema,
                                 options = options,
                             )
                         }


### PR DESCRIPTION
### Motivation
- Fix a Kotlin compile error caused by referencing a non-existent `current.schema` when materializing a patched snapshot.
- Resolve a docs verification failure (`verifyRecipesDocs`) by bringing example code in the recipes docs in line with the current API.

### Description
- In `konditional-serialization/src/main/kotlin/.../ConfigurationSnapshotCodec.kt` pass the explicit `schema` parameter into `toConfiguration` (`schema = schema`) instead of using `current.schema`.
- Regenerated and updated `docusaurus/docs/advanced/recipes.md` to use the current names and shapes (`materialized` → `configuration` and `load(candidateConfig.configuration)` → `load(candidateConfig)`).

### Testing
- Ran `./gradlew :konditional-observability:generateRecipesDocs` and it completed successfully.
- Ran `make build` (which executes `./gradlew build`) and the full build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699efb220280832988d0c43ba50e6d35)