### PR TITLE
docs: update install & reference to facade module and snapshot export API

### DIFF
--- a/docusaurus/docs/quickstart/install.md
+++ b/docusaurus/docs/quickstart/install.md
@@ -5,26 +5,27 @@ sidebar_position: 2
 
 # Install
 
-Add the minimal modules for typed declarations and runtime loading.
+Add the minimal modules for typed declarations, runtime loading, and JSON
+boundary support.
 
 **Prerequisites:** You have completed [Quickstart](/quickstart/).
 
 <span id="claim-clm-pr01-07a"></span>
-Installation targets the core namespace model and runtime in-memory registry implementation.
+Installation targets the facade module that bundles the default runtime stack
+(`runtime` + transitive `core` and `serialization`).
 
 ```kotlin
 // build.gradle.kts
 
 dependencies {
-  implementation("io.github.amichne:konditional-core:VERSION")
-  implementation("io.github.amichne:konditional-runtime:VERSION")
+  implementation("io.github.amichne:konditional:VERSION")
 }
 ```
 
 Run a compile task:
 
 ```bash
-./gradlew :konditional-core:compileKotlin
+./gradlew compileKotlin
 ```
 
 ## Expected Outcome
@@ -39,4 +40,4 @@ After this step, your project resolves Konditional dependencies and compiles suc
 
 | Claim ID | Statement |
 | --- | --- |
-| CLM-PR01-07A | Installation targets the core namespace model and runtime in-memory registry implementation. |
+| CLM-PR01-07A | Installation targets the default facade module that resolves runtime, core, and serialization transitively. |

--- a/docusaurus/docs/reference/api/namespace-operations.md
+++ b/docusaurus/docs/reference/api/namespace-operations.md
@@ -10,6 +10,8 @@ Namespace runtime operations from `io.amichne.konditional.runtime`.
 
 ```kotlin
 fun Namespace.update(configuration: Configuration)
+fun Namespace.dump(): String
+val Namespace.json: String
 fun Namespace.rollback(steps: Int = 1): Boolean
 val Namespace.history: List<ConfigurationView>
 val Namespace.historyMetadata: List<ConfigurationMetadataView>
@@ -28,6 +30,16 @@ result
     val parseError = failure.parseErrorOrNull()
     logger.error { parseError?.message ?: failure.message.orEmpty() }
   }
+```
+
+## Snapshot Export
+
+`Namespace.dump()` serializes the namespace's current immutable snapshot into canonical JSON.
+`Namespace.json` is a convenience accessor equivalent to `dump()`.
+
+```kotlin
+val snapshotJson = AppFeatures.dump()
+val snapshotJsonViaProperty = AppFeatures.json
 ```
 
 ## Kill Switch

--- a/docusaurus/docs/reference/migration-guide.md
+++ b/docusaurus/docs/reference/migration-guide.md
@@ -21,27 +21,33 @@ Use this sequence to get value quickly:
 
 ---
 
-## Migrating from the legacy monolith (`io.amichne:konditional`) to split artifacts
+## Migrating from split artifacts to the facade module (`io.github.amichne:konditional`)
 
-Konditional is now published as split modules.
+Konditional now provides a facade artifact for the default runtime package.
 
-- **Guarantee**: `konditional-core` is implementation-free; it contains the DSL + evaluation surface.
-- **Mechanism**: runtime implementations are discovered via `ServiceLoader` (see `NamespaceRegistryFactory`).
-- **Boundary**: if no runtime factory is present, namespace initialization fails fast with a clear error.
+- **Guarantee**: facade usage preserves existing runtime behavior and public APIs.
+- **Mechanism**: `konditional` depends on `konditional-runtime`, which transitively includes `konditional-core` and `konditional-serialization`.
+- **Boundary**: optional modules (`konditional-observability`, `konditional-otel`, `konditional-http-server`, `openfeature`, `kontracts`, `openapi`) remain opt-in.
 
 ### Dependencies
 
 ```kotlin
 dependencies {
-    // Required for normal usage
-    implementation("io.amichne:konditional-core:0.0.1")
-    implementation("io.amichne:konditional-runtime:0.0.1")
-
-    // Optional (JSON)
-    implementation("io.amichne:konditional-serialization:0.0.1")
+    // Recommended default
+    implementation("io.github.amichne:konditional:VERSION")
 
     // Optional (shadow evaluation + utilities)
-    implementation("io.amichne:konditional-observability:0.0.1")
+    implementation("io.github.amichne:konditional-observability:VERSION")
+}
+```
+
+If you intentionally need granular control, keep explicit split artifacts:
+
+```kotlin
+dependencies {
+    implementation("io.github.amichne:konditional-core:VERSION")
+    implementation("io.github.amichne:konditional-runtime:VERSION")
+    implementation("io.github.amichne:konditional-serialization:VERSION")
 }
 ```
 
@@ -52,21 +58,20 @@ dependencies {
 | Load config into a namespace | `AppFeatures.load(configuration)`                                       | `AppFeatures.load(configuration)` + `import io.amichne.konditional.runtime.load` |
 | Rollback/history             | `AppFeatures.rollback(...)` / `historyMetadata`                         | same calls + imports from `io.amichne.konditional.runtime.*`                     |
 | Configuration model          | `io.amichne.konditional.core.instance.*`                                | `io.amichne.konditional.serialization.instance.*`                                |
-| Snapshot codecs              | `io.amichne.konditional.serialization.snapshot.*`                       | same packages; add `konditional-serialization` dependency                        |
-| Namespace snapshot loader    | `io.amichne.konditional.serialization.snapshot.NamespaceSnapshotLoader` | same package; add `konditional-runtime` dependency                               |
+| Snapshot codecs              | `io.amichne.konditional.serialization.snapshot.*`                       | same packages; facade includes serialization transitively                         |
+| Namespace snapshot loader    | `io.amichne.konditional.serialization.snapshot.NamespaceSnapshotLoader` | same package; available transitively via facade                                   |
 
 ## Breaking API Symbol Map (Result Refactor)
 
 | Removed / Changed | Replacement |
 |---|---|
 | `Result<T>` | Kotlin `Result<T>` |
-| `Feature.evaluate(...)` | Removed. Use `Feature.evaluate(...)` |
+| `Feature.evaluate(...)` | unchanged; this remains the supported public API |
 | `Feature.explainSafely(...)` | Removed |
 | `Feature.explain(...)` | Removed from public API |
-| Public `internal EvaluationDiagnostics<T>` | Removed from public API |
+| Public `EvaluationDiagnostics<T>` exposure | internalized (sibling-module opt-in only) |
 | `Version.parse(raw): Result<Version>` | `Version.parse(raw): Result<Version>` |
-| `SnapshotCodec.decode(...): Result<T>` | `SnapshotCodec.decode(...): Result<T>` |
-| `SnapshotLoader.load(...): Result<T>` | `SnapshotLoader.load(...): Result<T>` |
+| `SnapshotCodec` / `SnapshotLoader` boundary types | removed; use `ConfigurationSnapshotCodec` and `NamespaceSnapshotLoader` |
 | `ConfigurationSnapshotCodec.decode(...): Result<TrustedSnapshotWrapper>` | `ConfigurationSnapshotCodec.decode(...): Result<Configuration>` |
 | `Namespace.update(configuration: TrustedSnapshotWrapper)` extension | `Namespace.update(configuration: Configuration)` |
 

--- a/docusaurus/docs/reference/module-dependency-map.md
+++ b/docusaurus/docs/reference/module-dependency-map.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # Module Dependency Map
 
-Pick the smallest set of modules that covers your use case. Most applications need three.
+Pick the smallest set of modules that covers your use case. Most applications can start with the facade module and add specialized modules only when needed.
 
 ---
 
@@ -13,6 +13,7 @@ Pick the smallest set of modules that covers your use case. Most applications ne
 
 ```mermaid
 graph TD
+    FACADE["konditional<br>Facade: runtime + transitive core/serialization"]
     CORE["konditional-core<br>Namespace · Feature · evaluate()"]
     RUNTIME["konditional-runtime<br>load · rollback · disableAll"]
     SERIAL["konditional-serialization<br>JSON → ParseResult&lt;Configuration&gt;"]
@@ -34,6 +35,7 @@ graph TD
     OF --> CORE
     KONTRACTS --> CORE
     OPENAPI --> KONTRACTS
+    FACADE --> RUNTIME
 ```
 
 Arrows point from dependent → dependency. `konditional-core` is the only module with no runtime dependencies within
@@ -42,6 +44,18 @@ this graph.
 ---
 
 ## Module Reference
+
+### Layer 0 — Facade (recommended default)
+
+**`konditional`** `io.github.amichne:konditional:VERSION`
+
+Default entry point for most applications. This facade depends on `konditional-runtime` and therefore transitively pulls `konditional-core` and `konditional-serialization`.
+
+- Fastest path to typed evaluation + runtime updates + JSON snapshot ingestion
+- Prefer this unless you intentionally want a thinner dependency graph
+- [Quickstart: Install](/quickstart/install) · [Reference: Namespace Operations API](/reference/api/namespace-operations)
+
+---
 
 ### Layer 1 — Core (always required)
 
@@ -149,8 +163,9 @@ external consumers.
 
 | Starting point | Modules |
 |---|---|
+| **Evaluate + load remote config** (most applications) | `konditional` |
 | **Evaluate static flags only** (no remote config) | `konditional-core` |
-| **Evaluate + load remote config** (most applications) | `konditional-core` + `konditional-runtime` + `konditional-serialization` |
+| **Custom minimal graph** | `konditional-core` + `konditional-runtime` + `konditional-serialization` |
 | **Migrating from a legacy flag system** | above + `konditional-observability` |
 | **Production at scale** (telemetry, hosted delivery) | above + `konditional-otel` + `konditional-http-server` |
 | **OpenFeature compatibility** | above + `openfeature` |

--- a/docusaurus/docs/serialization/reference.md
+++ b/docusaurus/docs/serialization/reference.md
@@ -2,13 +2,16 @@
 
 JSON snapshot and patch APIs at the untrusted boundary.
 
-## `ConfigurationSnapshotCodec.encode(...)`
+## `ConfigurationSnapshotCodec.encode(...)` (legacy infrastructure entrypoint)
 
 ```kotlin
 object ConfigurationSnapshotCodec {
     fun encode(value: ConfigurationView): String
 }
 ```
+
+Prefer `Namespace.dump()` from `io.amichne.konditional.runtime` for namespace-scoped snapshot export.
+`encode(...)` remains available for infrastructure/test code that already holds a `ConfigurationView`.
 
 ## `ConfigurationSnapshotCodec.decode(...)`
 


### PR DESCRIPTION
### Motivation

- Reflect recent code changes that introduce a facade artifact that bundles `konditional-runtime` with transitive `core`/`serialization` and surface the preferred runtime entrypoints in docs. 
- Make the docs consistent with runtime API changes: `Namespace.update(...)` is the supported load entrypoint and `Namespace.dump()` / `Namespace.json` are the preferred snapshot export surfaces. 
- Remove or de-emphasize deprecated/removed serialization boundary types and surface-level codec entrypoints so migration guidance is accurate.

### Description

- Updated Quickstart `Install` to recommend the facade artifact `io.github.amichne:konditional` and switched the example Gradle block and compile command to the facade usage (`implementation("io.github.amichne:konditional:VERSION")` and `./gradlew compileKotlin`).
- Expanded the Module Dependency Map with a new facade layer and adjusted recommendations so most applications start with the `konditional` facade (added facade node to the dependency graph and starting-point table). 
- Documented runtime snapshot export in Namespace Operations by adding `Namespace.dump()` and `Namespace.json` and a short example usage, and clarified that `Namespace.update(...)` is the runtime load API. 
- Clarified `ConfigurationSnapshotCodec.encode(...)` as a legacy infrastructure entrypoint and pointed consumers to `Namespace.dump()` for namespace-scoped export, and updated the Migration Guide to reflect the facade-first recommendation and the internalization/removal of older snapshot boundary types. 

### Testing

- Ran the documentation build via `make docs-build` which completed successfully and produced the static site artifacts. 
- The Docusaurus build reported existing broken-link warnings (two pre-existing links reported under `/advanced/recipes`), but the build itself succeeded. 
- Committed the documentation changes and verified the local diff and files were updated accordingly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f3142d1d08329ac468eb76f6b8ccc)