### PR TITLE
ci(release): publish facade-only artifacts and use tag-derived version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,23 +115,15 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
 
-      - name: Validate version matches tag
+      - name: Resolve release version from tag
+        id: release-version
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-          GRADLE_VERSION=$(./gradlew properties -q | grep "^version:" | awk '{print $2}')
-
-          echo "Tag version: $TAG_VERSION"
-          echo "Gradle version: $GRADLE_VERSION"
-
-          if [ "$TAG_VERSION" != "$GRADLE_VERSION" ]; then
-            echo "ERROR: Version mismatch between tag ($TAG_VERSION) and gradle.properties ($GRADLE_VERSION)"
-            exit 1
-          fi
-
-          echo "✓ Version validated: $TAG_VERSION"
+          echo "release=$TAG_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Using release version from tag: $TAG_VERSION"
 
       - name: Run tests
-        run: ./gradlew test --no-daemon
+        run: ./gradlew test -Pversion="${{ steps.release-version.outputs.release }}" --no-daemon
 
   publish-maven-central:
     if: github.event_name == 'push'
@@ -209,7 +201,8 @@ jobs:
             SIGNING_ARGS+=(-Psigning.gnupg.passphrase="$SIGNING_GPG_PASSPHRASE")
           fi
 
-          ./gradlew publishAndReleaseToMavenCentral "${SIGNING_ARGS[@]}" \
+          ./gradlew :konditional:publishAndReleaseToMavenCentral "${SIGNING_ARGS[@]}" \
+            -Pversion="${GITHUB_REF#refs/tags/v}" \
             --no-configuration-cache \
             --no-daemon \
             --stacktrace
@@ -268,7 +261,8 @@ jobs:
             SIGNING_ARGS+=(-Psigning.gnupg.passphrase="$SIGNING_GPG_PASSPHRASE")
           fi
 
-          ./gradlew publishMavenPublicationToGitHubPackagesRepository "${SIGNING_ARGS[@]}" \
+          ./gradlew :konditional:publishMavenPublicationToGitHubPackagesRepository "${SIGNING_ARGS[@]}" \
+            -Pversion="${GITHUB_REF#refs/tags/v}" \
             --no-configuration-cache \
             --no-daemon \
             --stacktrace
@@ -297,13 +291,10 @@ jobs:
 
       - name: Build release artifacts
         run: |
-          ./gradlew assemble --no-daemon
+          ./gradlew :konditional:assemble -Pversion="${GITHUB_REF#refs/tags/v}" --no-daemon
           rm -rf release-artifacts
           mkdir -p release-artifacts
-          find . -type f -path "*/build/libs/*.jar" \
-            ! -path "./build-logic/*" \
-            ! -path "./detekt-rules/*" \
-            -exec cp {} release-artifacts/ \;
+          find konditional/build/libs -maxdepth 1 -type f -name '*.jar' -exec cp {} release-artifacts/ \;
           if [ -z "$(find release-artifacts -maxdepth 1 -name '*.jar' -print -quit)" ]; then
             echo "No release artifacts found in module build/libs directories"
             exit 1


### PR DESCRIPTION
### Motivation
- Prevent release failures caused by mismatches between `gradle.properties` and the git tag by making the tag the authoritative source of the release SemVer.
- Reduce distribution surface and simplify publishing by releasing only the facade module artifacts (the `konditional` module).
- Ensure deterministic version continuity across tests, publish tasks, and GitHub Release artifact assembly by injecting the resolved version into Gradle invocations.

### Description
- Replaced the strict tag / `gradle.properties` validation with a tag-derived `release` output step that surfaces the release version via `GITHUB_OUTPUT` and is used by downstream steps.
- Inject the tag-derived version into Gradle invocations by passing `-Pversion="${GITHUB_REF#refs/tags/v}"` (and into test via `-Pversion`), and target publishing/assembly tasks to the facade module explicitly using `:konditional:...` Gradle paths.
- Narrowed publish tasks to the facade-only publications: `:konditional:publishAndReleaseToMavenCentral` and `:konditional:publishMavenPublicationToGitHubPackagesRepository` so only the facade is released.
- Restricted GitHub Release artifact collection to `konditional/build/libs/*.jar` and use `:konditional:assemble` to produce only facade artifacts.

### Testing
- Executed `./gradlew :konditional:publishAndReleaseToMavenCentral :konditional:publishMavenPublicationToGitHubPackagesRepository :konditional:assemble -Pversion=1.2.3 -m --no-daemon`, which completed successfully (`BUILD SUCCESSFUL`).
- Verified the modified release job flow locally by running `:konditional:assemble -Pversion=1.2.3`, and confirmed facade artifacts are produced in `konditional/build/libs`.
- Note: repository push/pull and `bd` workflow steps were not validated here due to the local checkout lacking a configured remote and the `bd` CLI not being present in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fd4a38e208329a4e34a30642f1312)