### PR TITLE
docs: regenerate recipes documentation

### DIFF
--- a/docusaurus/docs/advanced/recipes.md
+++ b/docusaurus/docs/advanced/recipes.md
@@ -60,7 +60,7 @@ Gradually roll out a feature without reshuffling users; use `salt(...)` when you
 
 ```kotlin
 object RampUpFlags : Namespace("ramp-up") {
-    val newCheckout by boolean<Context>(default = false) {
+    val newCheckout by boolean(default = false) {
         salt("v1")
         enable { rampUp { 10.0 } }
     }
@@ -74,7 +74,7 @@ To restart the experiment with a fresh sample:
 
 ```kotlin
 object RampUpResetFlags : Namespace("ramp-up-reset") {
-    val newCheckout by boolean<Context>(default = false) {
+    val newCheckout by boolean(default = false) {
         salt("v2")
         enable { rampUp { 10.0 } }
     }
@@ -100,7 +100,7 @@ enum class Segment(override val id: String) : AxisValue<Segment> {
 }
 
 object SegmentFlags : Namespace("segment") {
-    val premiumUi by boolean<Context>(default = false) {
+    val premiumUi by boolean(default = false) {
         enable {
             constrain(Segment.ENTERPRISE)
         }
@@ -108,21 +108,15 @@ object SegmentFlags : Namespace("segment") {
 }
 
 fun isPremiumUiEnabled(): Boolean {
-    val segmentContext =
-        object :
-            Context,
-            Context.LocaleContext,
-            Context.PlatformContext,
-            Context.VersionContext,
-            Context.StableIdContext {
-            override val locale = AppLocale.UNITED_STATES
-            override val platform = Platform.IOS
-            override val appVersion = Version.of(2, 1, 0)
-            override val stableId = StableId.of("user-123")
+    val segmentContext = object : Context, LocaleContext, PlatformContext, VersionContext, StableIdContext {
+        override val locale = AppLocale.UNITED_STATES
+        override val platform = Platform.IOS
+        override val appVersion = Version.of(2, 1, 0)
+        override val stableId = StableId.of("user-123")
 
-            // Ultra-concise: no DSL wrapper needed
-            override val axes = io.amichne.konditional.context.axis.axes(Segment.ENTERPRISE)
-        }
+        // Ultra-concise: no DSL wrapper needed
+        override val axes = axes(Segment.ENTERPRISE)
+    }
 
     return SegmentFlags.premiumUi.evaluate(segmentContext)
 }
@@ -147,7 +141,7 @@ data class EnterpriseContext(
     override val stableId: StableId,
     val subscriptionTier: SubscriptionTier,
     val employeeCount: Int,
-) : Context, Context.LocaleContext, Context.PlatformContext, Context.VersionContext, Context.StableIdContext
+) : Context, LocaleContext, PlatformContext, VersionContext, StableIdContext
 
 enum class SubscriptionTier { FREE, PRO, ENTERPRISE }
 


### PR DESCRIPTION
### Motivation
- Regenerate the recipes docs so Kotlin examples stay in sync with the current API and avoid stale or non-compiling snippets.
- Ensure recipe examples reflect the preferred, type-safe idioms used across the codebase (compile-time correctness and concise context usage).

### Description
- Regenerated `docusaurus/docs/advanced/recipes.md` so Kotlin snippets are updated to the current helper signatures and idioms.
- Replaced occurrences like `boolean<Context>(default = ...)` with `boolean(default = ...)` and removed redundant `Context.` qualifiers on mixin interfaces (for example `Context.LocaleContext` → `LocaleContext`).
- Simplified axis construction from fully-qualified `io.amichne.konditional.context.axis.axes(...)` to `axes(...)` and applied minor formatting/indentation cleanups in examples.
- This change only touches documentation content and does not modify runtime logic or public APIs beyond example code.

### Testing
- Ran `./gradlew konditional-observability:generateRecipesDocs`, which completed successfully.
- Ran `./gradlew konditional-observability:verifyRecipesDocs`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6e0953c008329905e881a4ba26cab)